### PR TITLE
fix: pin MCP SDK below v2 for FastMCP compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "mcp[cli]>=1.0.0",
+    "mcp[cli]>=1.0.0,<2",
     "openai>=1.40.0",
     "httpx[socks]>=0.27.0",  # 兼容 SOCKS 代理（科学上网环境常见）
 ]


### PR DESCRIPTION
## Summary

Pin `mcp[cli]` to `<2`.

The current implementation imports `mcp.server.fastmcp.FastMCP`, but MCP SDK 2.x renamed/changed the FastMCP APIs. With a fresh install, `pip install -e .` currently resolves to MCP 2.x and `deepseek-mcp` fails to start.

## Reproduction

Environment:
- Windows
- Python 3.11
- fresh virtual environment

After:

`pip install -e .`

pip installed MCP 2.1.1.

Running `deepseek-mcp` then failed with:

`ModuleNotFoundError: No module named 'mcp.server.fastmcp'.`

## Fix

Change the dependency from:

`mcp[cli]>=1.0.0`

to:

`mcp[cli]>=1.0.0,<2`

This keeps the current FastMCP-based implementation on the compatible MCP 1.x SDK.

## Validation

After installing MCP 1.x, `deepseek-mcp` starts successfully and can be registered and used as an MCP server in Codex.