### PR TITLE
fix: isolate Bash subprocess stdin from MCP stdio

### DIFF
--- a/src/deepseek_mcp/tools.py
+++ b/src/deepseek_mcp/tools.py
@@ -165,6 +165,7 @@ def _execute_bash(args: dict, workspace: Path) -> str:
             command,
             shell=True,
             capture_output=True,
+            stdin=subprocess.DEVNULL,
             text=False,
             timeout=timeout,
             cwd=str(workspace),


### PR DESCRIPTION
## Summary

Prevent Bash subprocesses from inheriting the MCP server's stdin by passing `stdin=subprocess.DEVNULL` to `subprocess.run()`.

I encountered a reproducible hang when running Python scripts through the DeepSeek subagent on Windows with Codex Desktop using stdio MCP.

## Environment

- Windows
- Python 3.11
- Codex Desktop
- MCP stdio transport

## Reproduction

With a simple `main.py` that immediately prints `4.0`:

- `python --version` through the Bash tool returned normally.
- `python main.py` hung until the outer MCP call timed out.
- Running the same command directly in PowerShell returned immediately.
- Calling `_execute_bash()` directly from Python also returned immediately.
- `python main.py < NUL` through the MCP Bash tool returned immediately with exit code 0.

This suggested that the child process was interacting with or inheriting the stdio stream used by the MCP server.

## Fix

Pass `subprocess.DEVNULL` as stdin:

```python
result = subprocess.run(
    command,
    shell=True,
    capture_output=True,
    stdin=subprocess.DEVNULL,
    text=False,
    timeout=timeout,
    cwd=str(workspace),
)
```

## Validation

After applying the change and fully restarting the `deepseek-mcp` process, the previously hanging command:

`python main.py`

returned normally through Codex Desktop:

```text
stdout:
4.0

stderr:
(empty)

exit code: 0
```

A subsequent full delegated task also completed successfully, including reading the file, running tests, and executing `python main.py`.