### PR TITLE
fix: handle Windows 8.3 path aliases in secure file I/O

### DIFF
--- a/adapters/codex/windows_file_io.py
+++ b/adapters/codex/windows_file_io.py
@@ -142,13 +142,15 @@ def _attributes(handle: int) -> int:
     return int(info.attributes)
 
 
-def _validate(handle: int, expected: str, *, directory: bool) -> None:
+def _validate(handle: int, expected: str, *, directory: bool) -> str:
     attributes = _attributes(handle)
     actual_directory = bool(attributes & _DIRECTORY)
     if attributes & _REPARSE or actual_directory != directory:
         raise WindowsPathError("Codex config path is a reparse point or wrong type")
-    if _final_path(handle) != expected:
+    canonical = _shared_windows_file_io._canonical_existing_path(expected)
+    if _final_path(handle) != canonical:
         raise WindowsPathError("Codex config path escaped its expected location")
+    return canonical
 
 
 def _validate_acl(handle: int) -> None:
@@ -166,18 +168,18 @@ def _open_parent(path: Path) -> _Directory:
     handle = _open(current, _READ, _OPEN_EXISTING, directory=True, share=_SHARE_RW)
     ancestors: list[int] = []
     try:
-        _validate(handle, current, directory=True)
+        current = _validate(handle, current, directory=True)
         for part in (piece for piece in tail.split("\\") if piece):
             candidate = _normalized(ntpath.join(current, part))
             child = _open(candidate, _READ, _OPEN_EXISTING, directory=True, share=_SHARE_RW)
             try:
-                _validate(child, candidate, directory=True)
+                canonical = _validate(child, candidate, directory=True)
             except BaseException:
                 with suppress(OSError):
                     _close(child)
                 raise
             ancestors.append(handle)
-            handle, current = child, candidate
+            handle, current = child, canonical
         _validate_acl(handle)
         return _Directory(handle, current, tuple(ancestors))
     except BaseException:

--- a/src/deepseek_mcp/windows_file_io.py
+++ b/src/deepseek_mcp/windows_file_io.py
@@ -44,6 +44,9 @@ if os.name == "nt":  # pragma: no cover - exercised by the Windows CI matrix
         wintypes.HANDLE, wintypes.LPWSTR, wintypes.DWORD, wintypes.DWORD,
     )
     _FINAL_PATH.restype = wintypes.DWORD
+    _GET_LONG_PATH = _KERNEL32.GetLongPathNameW
+    _GET_LONG_PATH.argtypes = (wintypes.LPCWSTR, wintypes.LPWSTR, wintypes.DWORD)
+    _GET_LONG_PATH.restype = wintypes.DWORD
     _GET_HANDLE_INFO = _KERNEL32.GetFileInformationByHandleEx
     _GET_HANDLE_INFO.argtypes = (
         wintypes.HANDLE, ctypes.c_int, wintypes.LPVOID, wintypes.DWORD,
@@ -124,6 +127,18 @@ def _final_path(handle: int) -> str:
     return _normalized(buffer.value)
 
 
+def _canonical_existing_path(path: str) -> str:
+    """Expand Windows 8.3 aliases without resolving through a reparse point."""
+    size = _GET_LONG_PATH(path, None, 0)
+    if not size:
+        raise ctypes.WinError(ctypes.get_last_error())
+    buffer = ctypes.create_unicode_buffer(size + 1)
+    written = _GET_LONG_PATH(path, buffer, len(buffer))
+    if not written or written >= len(buffer):
+        raise ctypes.WinError(ctypes.get_last_error())
+    return _normalized(buffer.value)
+
+
 def _attributes(handle: int) -> int:
     info = _AttributeTagInfo()
     ok = _GET_HANDLE_INFO(
@@ -134,13 +149,15 @@ def _attributes(handle: int) -> int:
     return int(info.attributes)
 
 
-def _validate_handle(handle: int, expected: str, *, directory: bool) -> None:
+def _validate_handle(handle: int, expected: str, *, directory: bool) -> str:
     attributes = _attributes(handle)
     actual_directory = bool(attributes & _DIRECTORY)
     if attributes & _REPARSE or actual_directory != directory:
         raise WindowsPathError("Windows path is a reparse point or wrong type")
-    if _final_path(handle) != expected:
+    canonical = _canonical_existing_path(expected)
+    if _final_path(handle) != canonical:
         raise WindowsPathError("Windows path escaped its expected location")
+    return canonical
 
 
 def _validate_acl(handle: int) -> None:
@@ -156,17 +173,17 @@ def _open_directory(path: Path) -> _Directory:
     current = _normalized(drive + "\\")
     handle = _open(current, directory=True)
     try:
-        _validate_handle(handle, current, directory=True)
+        current = _validate_handle(handle, current, directory=True)
         for part in (piece for piece in tail.split("\\") if piece):
             candidate = _normalized(ntpath.join(current, part))
             child = _open(candidate, directory=True)
             try:
-                _validate_handle(child, candidate, directory=True)
+                canonical = _validate_handle(child, candidate, directory=True)
             except BaseException:
                 _close(child)
                 raise
             _close(handle)
-            handle, current = child, candidate
+            handle, current = child, canonical
         _validate_acl(handle)
         return _Directory(handle, current)
     except BaseException:


### PR DESCRIPTION
Fix the Windows CI path-validation cascade caused by GitHub-hosted runners exposing temporary directories through 8.3 aliases such as `RUNNER~1` while `GetFinalPathNameByHandleW` returns the long form.

This keeps the existing security checks intact:
- reparse points remain rejected
- directory/file type checks remain enforced
- ACL validation remains enforced
- handle final paths are still compared against the exact expected path after Windows canonicalization

The traversal now carries the canonical long path forward so later parent-handle checks do not regress to the short alias.