### PR TITLE
fix: restore delegated output verification in host instructions

### DIFF
--- a/src/deepseek_mcp/host_instructions.py
+++ b/src/deepseek_mcp/host_instructions.py
@@ -2,8 +2,8 @@
 
 HOST_INSTRUCTIONS = """
 After any result with mutations—or cancellation, disconnection, or restart—call
-`get_deepseek_recovery`, verify the reported files, then call
-`acknowledge_deepseek_mutations(transaction_ids)` with the exact reviewed IDs.
+`get_deepseek_recovery`, verify delegated output and each changed file, then
+call `acknowledge_deepseek_mutations(transaction_ids)` with the exact reviewed IDs.
 
 API reference:
 - `ping()`: check that the MCP server is available.


### PR DESCRIPTION
## Problem

CI `Run tests` fails on main:

```
RuntimeError: MCP initialize returned incomplete host instructions
```

`adapters/codex/mcp_smoke.py:67` has pinned the phrase **"verify delegated
output"** in the required host instructions since the original feature commit
(`1c41714`). The reword in `27a3ed8` ("docs: clarify delegation API
selection") replaced it with "verify the reported files", dropping the safety
property the test encodes: the host must verify delegated coding output and
each changed file before acknowledging mutations.

## Fix

Restore the original phrase in `src/deepseek_mcp/host_instructions.py`,
keeping the improved wording from `27a3ed8` (cancellation / disconnection /
restart coverage, API reference format):

```diff
 After any result with mutations—or cancellation, disconnection, or restart—call
-`get_deepseek_recovery`, verify the reported files, then call
-`acknowledge_deepseek_mutations(transaction_ids)` with the exact reviewed IDs.
+`get_deepseek_recovery`, verify delegated output and each changed file, then
+call `acknowledge_deepseek_mutations(transaction_ids)` with the exact reviewed IDs.
```

The test is the source of truth here, so the instructions change — not the test.

## Verification

Full suite in a clean venv (CI-equivalent): `428 tests, OK (10 skipped)`,
including `test_codex_mcp_smoke` (real MCP stdio initialize/list_tools/ping)
and `test_server_annotations` (512-char instruction-window contract).