### PR TITLE
fix: restore delegated output verification in host instructions

### DIFF
--- a/src/deepseek_mcp/host_instructions.py
+++ b/src/deepseek_mcp/host_instructions.py
@@ -2,8 +2,9 @@
 
 HOST_INSTRUCTIONS = """
 After any result with mutations—or cancellation, disconnection, or restart—call
-`get_deepseek_recovery`, verify the reported files, then call
-`acknowledge_deepseek_mutations(transaction_ids)` with the exact reviewed IDs.
+`get_deepseek_recovery`, verify delegated output and each changed file, then
+call `acknowledge_deepseek_mutations(transaction_ids)` with the exact reviewed
+IDs.
 
 API reference:
 - `ping()`: check that the MCP server is available.


### PR DESCRIPTION
## Problem

CI (all 9 matrix jobs) fails on `test_initialize_list_tools_and_ping_over_stdio` (`tests/test_codex_mcp_smoke.py`):

    RuntimeError: MCP initialize returned incomplete host instructions

`adapters/codex/mcp_smoke.py` pins a contract on the server's `initialize` instructions: they must contain `delegate_to_deepseek`, `delegate_to_deepseek_readonly`, `get_deepseek_recovery`, `acknowledge_deepseek_mutations`, and the phrase **verify delegated output**.

## Root cause

`27a3ed8` reworded the recovery paragraph in `src/deepseek_mcp/host_instructions.py` and dropped the phrase "verify delegated output", regressing the smoke-test contract and weakening the safety property: the host must verify delegated coding output and each changed file before acknowledging mutations.

## Fix

Restore the phrase (mirroring `origin/fix/verify-delegated-output-instructions`), keeping the reworded cancellation/disconnection/restart coverage.

## Verification (local, Python 3.12)

- `adapters/codex/mcp_smoke.py` → `MCP initialize/list_tools/ping OK`
- `python -m unittest discover -s tests` → `Ran 428 tests, OK (skipped=10)`
- `pip check`, `pip-audit`, `compileall`, `bash -n` all pass