### PR TITLE
docs: tighten background mutation guarantees

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ result back. Token savings are end-to-end.
 - **Bash execution**: bounded credential-isolated trusted-host commands through the tool-child boundary
 - **Workspace path boundary** for file tools, with outbound symlinks rejected
 - **Cross-process execution lease** so two MCP servers cannot run DeepSeek concurrently against the same workspace
-- **Crash-safe mutation journal** with recovery query, file verification, and exact acknowledgement before another delegation
+- **Crash-safe mutation journal for Write / Edit / NotebookEdit** with recovery query, file verification, and exact acknowledgement before another delegation; trusted-host Bash changes are not journaled
 - **Explicit network retry policy** with OpenAI SDK internal retries disabled to avoid nested retry amplification in proxy/TLS-timeout environments
 - **Claude Code skill + `/ds` command** for delegation policy and forced delegation
 
@@ -199,12 +199,17 @@ the existing readonly job.
 
 If a steering message arrives after DeepSeek has planned tool calls but before a not-yet-executed tool runs, the stale tool call is skipped and DeepSeek re-plans from the new parent instruction.
 
-Only **one DeepSeek execution per canonical workspace** may run at a time, including executions started by separate MCP server processes. Background job IDs and results are session-scoped; collect the result before closing the host session.
+Only **one DeepSeek execution per canonical workspace** may run at a time, including executions started by separate MCP server processes. This lease coordinates DeepSeek MCP executions only; it cannot prevent the host agent, IDE, user, or another local process from changing the workspace. While a coding background job is running, the host should steer, query, or cancel that job rather than independently mutate the same workspace, then resume host-side edits after the job reaches a terminal state. Background job IDs and results are session-scoped; collect the result before closing the host session.
 
 ### Mutation recovery
 
-Every file mutation is journaled before commit. After a result reports
-mutations—or after cancellation, disconnection, or MCP restart—run:
+Mutations committed through `Write`, `Edit`, and `NotebookEdit` are journaled
+before commit. Trusted-host Bash runs outside this transaction journal and may
+modify workspace files directly; those changes are not represented by
+`get_deepseek_recovery`. After an interrupted coding run in which Bash may have
+executed, inspect the workspace independently before continuing or retrying work.
+After a result reports journaled mutations—or after cancellation, disconnection,
+or MCP restart—run:
 
 ```text
 get_deepseek_recovery()

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -100,7 +100,7 @@ Codex 和其它 MCP 客户端见下方安装说明。
 - **Bash 执行**：通过 tool-child 边界运行有界且隔离凭证的 `trusted_host`
 - **工作区路径边界**：文件工具拒绝指向工作区外的符号链接
 - **跨进程执行租约**：多个 MCP server 也不能同时对同一工作区执行 DeepSeek
-- **崩溃安全 mutation journal**：恢复查询、文件核验、精确确认完成前禁止再次委派
+- **Write / Edit / NotebookEdit 的崩溃安全 mutation journal**：恢复查询、文件核验、精确确认完成前禁止再次委派；`trusted_host` Bash 的改动不进入 journal
 - **显式网络重试策略**：关闭 OpenAI SDK 内层重试，避免代理/TLS timeout 环境下出现重试叠加
 - Claude Code 的 skill 与 `/ds` 命令；临时禁用请运行 `DEEPSEEK_MODE=off claude`
 
@@ -191,12 +191,15 @@ steering 会在模型 / 工具操作之间的安全点生效。cancel 会立即�
 
 如果新 steering 在 DeepSeek 已经规划出 tool call、但某个旧 tool call 尚未真正执行时到达，该旧 tool call 会被跳过，DeepSeek 下一轮直接按最新指令重新规划。
 
-每个规范化工作区同一时间只允许一个 DeepSeek execution，包括由不同 MCP server 进程启动的执行。后台 job ID 与结果只在当前 MCP session 内有效，关闭宿主前应先取回结果。
+每个规范化工作区同一时间只允许一个 DeepSeek execution，包括由不同 MCP server 进程启动的执行。这个租约只协调 DeepSeek MCP execution，无法阻止主 Agent、IDE、用户或其它本地进程修改工作区。coding 后台 job 运行期间，主 Agent 应优先通过 steering、status 或 cancel 控制该 job，不要同时独立修改同一工作区；等 job 进入终态后再恢复主 Agent 侧写入。后台 job ID 与结果只在当前 MCP session 内有效，关闭宿主前应先取回结果。
 
 ### 3. mutation 恢复
 
-每次文件 mutation 都会在 commit 前写入持久 journal。结果报告 mutation，或
-发生取消、断连、MCP 重启后，先执行：
+通过 `Write`、`Edit`、`NotebookEdit` 提交的 mutation 会在 commit 前写入持久
+journal。`trusted_host` Bash 不经过这套事务 journal，它可以直接修改、重命名、
+删除或生成工作区文件，这些变化不会出现在 `get_deepseek_recovery` 中。如果 coding
+任务中 Bash 可能已经执行后发生取消、断连或异常中断，应先独立检查工作区状态再继续
+或重试。结果报告 journal mutation，或发生取消、断连、MCP 重启后，先执行：
 
 ```text
 get_deepseek_recovery()

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,11 +51,23 @@ boundary. The trusted-host executor has workspace cwd, disabled stdin, bounded
 stdout/stderr, timeout, command checks, process-tree cleanup, and credential
 isolation. It supports macOS, Linux, and Windows.
 
+Bash is intentionally outside the crash-safe mutation journal. Shell commands
+may modify, rename, delete, or generate workspace files directly, and those
+changes are not represented by `get_deepseek_recovery`. The journal/recovery
+guarantee applies to mutations committed through Write, Edit, and NotebookEdit.
+After an interrupted coding run in which Bash may have executed, the host must
+inspect the workspace independently before continuing or retrying work.
+
 ## Concurrency, recovery, and lifecycle
 
 An OS-backed lease keyed by workspace filesystem identity prevents concurrent
 delegation against the same workspace. Different workspaces run independently.
 The lease is released after the active execution and its child processes finish.
+The lease coordinates DeepSeek MCP executions only; it cannot stop the host
+agent, an IDE, the user, or another local process from editing the same files.
+While a coding background job is running, the host should steer, query, or
+cancel that job instead of independently mutating the same workspace, then
+resume host-side edits after the job reaches a terminal state.
 
 Before `Write`, `Edit`, or `NotebookEdit` publishes an atomic replacement, the
 tool child persists a private mutation intent. `get_deepseek_recovery` audits

--- a/src/deepseek_mcp/host_instructions.py
+++ b/src/deepseek_mcp/host_instructions.py
@@ -1,9 +1,12 @@
 """Stable MCP host instructions, separated to keep the server entrypoint small."""
 
 HOST_INSTRUCTIONS = """
-After any result with mutations—or cancellation, disconnection, or restart—call
-`get_deepseek_recovery`, verify the reported files, then call
-`acknowledge_deepseek_mutations(transaction_ids)` with the exact reviewed IDs.
+Recovery records cover Write/Edit/NotebookEdit commits; trusted-host Bash changes
+are not transaction-journaled. After any result with reported mutations—or
+cancellation, disconnection, or restart—call `get_deepseek_recovery`, verify the
+reported files, then call `acknowledge_deepseek_mutations(transaction_ids)` with
+the exact reviewed IDs. If coding Bash may have run before an interruption,
+inspect the workspace independently before continuing.
 After every delegation, verify delegated output against the requested acceptance
 criteria before relying on it.
 
@@ -33,7 +36,10 @@ the job. Steering cannot enable Bash or mutation tools: if a readonly job later
 needs either, cancel or finish it and create a new coding job.
 
 DeepSeek cannot see host chat or project instructions; pass needed context
-explicitly. One OS lease permits one execution per canonical workspace.
-Background jobs/results are process-local. New delegation fails closed while
-recovery records remain.
+explicitly. One OS lease permits one DeepSeek execution per canonical workspace,
+but it cannot prevent the host, IDE, or other processes from editing that workspace.
+While a coding background job is running, the host should steer, query, or cancel
+that job instead of independently mutating the same workspace; resume host-side
+edits after the job reaches a terminal state. Background jobs/results are
+process-local. New delegation fails closed while recovery records remain.
 """.strip()

--- a/tests/test_provider_contract.py
+++ b/tests/test_provider_contract.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+import time
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from deepseek_mcp.agent_loop import _execute_planned_tools, _record_response
+from deepseek_mcp.provider_child import execute_request
+from deepseek_mcp.provider_response import ProviderResponse
+from deepseek_mcp.resource_budget import MutationBudget
+
+
+class _RawResponse:
+    def __init__(self, payload: bytes) -> None:
+        self.payload = payload
+        self.headers = {"content-encoding": "identity"}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args) -> None:
+        pass
+
+    def iter_bytes(self):
+        yield self.payload
+
+
+class ProviderContractTests(unittest.TestCase):
+    def test_v4_reasoning_tool_history_is_forwarded_on_next_request(self) -> None:
+        tool_payload = {
+            "usage": {"prompt_tokens": 12, "completion_tokens": 8},
+            "choices": [
+                {
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "reasoning_content": "inspect the requested file first",
+                        "tool_calls": [
+                            {
+                                "id": "call-readme",
+                                "type": "function",
+                                "function": {
+                                    "name": "Read",
+                                    "arguments": '{"path":"README.md"}',
+                                },
+                            }
+                        ],
+                    },
+                }
+            ],
+        }
+        response = ProviderResponse.from_payload(tool_payload)
+        state = SimpleNamespace(
+            config=SimpleNamespace(),
+            controls=SimpleNamespace(cancel=None, poll=None),
+            messages=[],
+            execution_lease_fd=None,
+            mutation_budget=MutationBudget(),
+            tool_calls=0,
+            deadline=time.monotonic() + 30,
+            prompt_tokens=0,
+            completion_tokens=0,
+            budget_tokens=0,
+            mutations=SimpleNamespace(add=lambda _record: None),
+        )
+
+        _record_response(state, response)
+        with patch(
+            "deepseek_mcp.agent_loop._execute_one_tool",
+            return_value="README contents",
+        ):
+            _execute_planned_tools(
+                state, response.choices[0].message.tool_calls, 0
+            )
+
+        final_payload = {
+            "usage": {"prompt_tokens": 24, "completion_tokens": 4},
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "message": {
+                        "role": "assistant",
+                        "content": "done",
+                    },
+                }
+            ],
+        }
+        captured: dict = {}
+
+        def create(**kwargs):
+            captured.update(kwargs)
+            return _RawResponse(json.dumps(final_payload).encode("utf-8"))
+
+        client = MagicMock()
+        client.chat.completions.with_streaming_response.create.side_effect = create
+        settings = {
+            "credential": "placeholder",
+            "base_url": "https://api.deepseek.com",
+            "model": "deepseek-v4-pro",
+        }
+        tools = [{"type": "function", "function": {"name": "Read"}}]
+
+        with patch("deepseek_mcp.provider_child.OpenAI", return_value=client):
+            result = execute_request(settings, state.messages, tools, 10)
+
+        self.assertEqual(result["kind"], "ok")
+        history = captured["messages"]
+        self.assertEqual(history[0]["role"], "assistant")
+        self.assertEqual(
+            history[0]["reasoning_content"],
+            "inspect the requested file first",
+        )
+        self.assertEqual(history[0]["content"], "")
+        self.assertEqual(history[0]["tool_calls"][0]["id"], "call-readme")
+        self.assertEqual(
+            history[0]["tool_calls"][0]["function"]["name"], "Read"
+        )
+        self.assertEqual(
+            history[1],
+            {
+                "role": "tool",
+                "tool_call_id": "call-readme",
+                "content": "README contents",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- clarify that crash-safe mutation recovery covers `Write` / `Edit` / `NotebookEdit`, not arbitrary trusted-host Bash mutations
- tell host agents not to independently mutate the same workspace while a coding background job is active
- keep English and Simplified Chinese README/security guidance aligned
- add a DeepSeek V4 contract test proving `reasoning_content` and the matching tool-call history are forwarded on the next provider request

## Scope

This intentionally does **not** change Bash execution, mutation journaling, workspace locking, provider retry behavior, MCP SDK version, or any other production execution algorithm.

## Risk

Low: production behavior is unchanged except for host guidance text. The only code addition is a test fixture.
