### PR TITLE
feat: add Flash/Pro model selection

### DIFF
--- a/docs/model-selection.md
+++ b/docs/model-selection.md
@@ -1,0 +1,12 @@
+# DeepSeek model selection
+
+The public delegation API supports exactly two model profiles:
+
+- `flash` -> `deepseek-v4-flash`
+- `pro` -> `deepseek-v4-pro`
+
+All four delegation entry points default to `model="flash"` when the argument is omitted. Use `model="pro"` only when the host decides the task needs the stronger model, for example complex debugging, architecture work, or a retry after Flash is insufficient.
+
+A background job keeps the model chosen when it starts. Steering messages do not change the model of an already-running job.
+
+The `model` field in the legacy config remains accepted for compatibility, but public delegation calls select Flash by default and override it with the per-call `flash` / `pro` choice.

--- a/src/deepseek_mcp/config.py
+++ b/src/deepseek_mcp/config.py
@@ -15,7 +15,7 @@ from .safety import is_unsafe_workspace_root
 from .workspace_guard import configure_workspace_identity
 CONFIG_PATH = Path.home() / ".deepseek-mcp" / "config.json"
 MAX_CONFIG_BYTES = 1024 * 1024
-DEFAULT_MODEL = "deepseek-v4-pro"
+DEFAULT_MODEL = "deepseek-v4-flash"
 DEFAULT_MAX_TURNS = 50
 MAX_TURNS = 100
 DEFAULT_MAX_RUN_SECONDS = 5 * 60 * 60

--- a/src/deepseek_mcp/host_instructions.py
+++ b/src/deepseek_mcp/host_instructions.py
@@ -28,10 +28,17 @@ API reference:
 - `acknowledge_deepseek_mutations(transaction_ids)`: acknowledge exact reviewed IDs.
 `task` states the goal and acceptance criteria; optional `context` supplies paths,
 constraints, and project conventions. `model` is exactly `flash` or `pro`: omit it
-for Flash; choose Pro for unusually difficult debugging, architecture, complex
-multi-file reasoning, or a retry when Flash was insufficient. A background job
-keeps the model chosen at start; steering cannot change it. `job_id` comes from
-`start_*`.
+for Flash. A background job keeps the model chosen at start; steering cannot change
+it. `job_id` comes from `start_*`.
+
+Model routing guidance:
+- `flash`: default general-purpose subagent, roughly Sonnet/Terra-tier. Use it for
+  normal coding, review, investigation, refactoring, and routine multi-file work.
+- `pro`: stronger difficult-task subagent, roughly Opus/Sol-tier. Use it for complex
+  debugging, architecture, difficult multi-file reasoning, or when Flash was
+  insufficient.
+Do not select Pro merely because it is available; prefer Flash unless the task
+clearly benefits from the stronger tier.
 
 Selection: use `delegate_*` when the host can wait for completion. Use `start_*`
 when it needs steering, status, or cancellation. Use readonly only for pure

--- a/src/deepseek_mcp/host_instructions.py
+++ b/src/deepseek_mcp/host_instructions.py
@@ -12,13 +12,14 @@ criteria before relying on it.
 
 API reference:
 - `ping()`: check that the MCP server is available.
-- `delegate_to_deepseek(task, context="")`: wait for full coding to finish; it
-  cannot be steered, queried, or cancelled while running.
-- `delegate_to_deepseek_readonly(task, context="")`: wait for file-only analysis
-  with Read/Glob/Grep; it has no Bash or mutation tools and cannot be controlled
-  while running.
-- `start_deepseek(task, context="")` / `start_deepseek_readonly(task, context="")`:
-  start a coding/read-only background job and return `job_id`.
+- `delegate_to_deepseek(task, context="", model="flash")`: wait for full coding to
+  finish; it cannot be steered, queried, or cancelled while running.
+- `delegate_to_deepseek_readonly(task, context="", model="flash")`: wait for
+  file-only analysis with Read/Glob/Grep; it has no Bash or mutation tools and
+  cannot be controlled while running.
+- `start_deepseek(task, context="", model="flash")` /
+  `start_deepseek_readonly(task, context="", model="flash")`: start a coding or
+  read-only background job and return `job_id`.
 - `get_deepseek_status(job_id)`: read a background job's state.
 - `send_deepseek_message(job_id, message)`: add or correct its task instruction.
 - `cancel_deepseek(job_id)`: cancel a background job.
@@ -26,7 +27,11 @@ API reference:
 - `get_deepseek_recovery()`: list unacknowledged mutations from coding work.
 - `acknowledge_deepseek_mutations(transaction_ids)`: acknowledge exact reviewed IDs.
 `task` states the goal and acceptance criteria; optional `context` supplies paths,
-constraints, and project conventions. `job_id` comes from `start_*`.
+constraints, and project conventions. `model` is exactly `flash` or `pro`: omit it
+for Flash; choose Pro for unusually difficult debugging, architecture, complex
+multi-file reasoning, or a retry when Flash was insufficient. A background job
+keeps the model chosen at start; steering cannot change it. `job_id` comes from
+`start_*`.
 
 Selection: use `delegate_*` when the host can wait for completion. Use `start_*`
 when it needs steering, status, or cancellation. Use readonly only for pure

--- a/src/deepseek_mcp/model_selection.py
+++ b/src/deepseek_mcp/model_selection.py
@@ -1,0 +1,19 @@
+"""Public DeepSeek model profiles exposed to MCP hosts."""
+from __future__ import annotations
+
+from typing import Literal
+
+ModelChoice = Literal["flash", "pro"]
+
+_MODEL_IDS = {
+    "flash": "deepseek-v4-flash",
+    "pro": "deepseek-v4-pro",
+}
+
+
+def resolve_model(choice: str) -> str:
+    """Resolve the stable public profile to the provider model id."""
+    try:
+        return _MODEL_IDS[choice]
+    except KeyError:
+        raise ValueError("model must be exactly 'flash' or 'pro'") from None

--- a/src/deepseek_mcp/server.py
+++ b/src/deepseek_mcp/server.py
@@ -18,7 +18,6 @@ import stat
 import sys
 from pathlib import Path
 from threading import Event, Lock
-from typing import Literal
 
 # Windows defaults to ProactorEventLoop, which can deadlock with stdio subprocesses.
 # Switch before importing/starting FastMCP.
@@ -38,6 +37,7 @@ from .execution_profile import (
 )
 from .host_instructions import HOST_INSTRUCTIONS as _HOST_INSTRUCTIONS
 from .job_manager import DeepSeekJobManager, JobBusy, JobError, validate_delegation_input
+from .model_selection import ModelChoice, resolve_model
 from .private_logging import PrivateBoundedLogStream
 from .process_hardening import disable_core_dumps
 from .transaction_recovery import (
@@ -46,25 +46,12 @@ from .transaction_recovery import (
 )
 
 _VALID_MODES = frozenset({"auto", "off"})
-_MODEL_IDS = {
-    "flash": "deepseek-v4-flash",
-    "pro": "deepseek-v4-pro",
-}
-
 
 def _deepseek_mode() -> str:
     value = os.getenv("DEEPSEEK_MODE", "auto")
     if value not in _VALID_MODES:
         raise JobError("DEEPSEEK_MODE must be exactly 'auto' or 'off'")
     return value
-
-
-def _resolve_model(model: str) -> str:
-    try:
-        return _MODEL_IDS[model]
-    except KeyError:
-        raise JobError("model must be exactly 'flash' or 'pro'") from None
-
 
 logger = logging.getLogger(__name__)
 _PACKAGE_LOGGER = logging.getLogger("deepseek_mcp")
@@ -183,7 +170,6 @@ _RECOVERY_ACK = ToolAnnotations(
     readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False,
 )
 
-
 @mcp.tool(annotations=_READ_ONLY)
 def ping() -> str:
     """Health check for the deepseek-mcp server.
@@ -205,7 +191,6 @@ def ping() -> str:
         config_status = f"NOT_CONFIGURED ({e})"
     return f"pong from deepseek-mcp v{__version__} | mode={mode} | {config_status}"
 
-
 @mcp.tool(annotations=_RESULT_WITH_BOOKKEEPING)
 def get_deepseek_recovery() -> str:
     """List durable, unacknowledged workspace mutation outcomes."""
@@ -214,7 +199,6 @@ def get_deepseek_recovery() -> str:
     except (RuntimeError, TransactionRecoveryError) as error:
         return _json({"ok": False, "error": str(error)})
     return _json({"ok": True, "pending": records, "count": len(records)})
-
 
 @mcp.tool(annotations=_RECOVERY_ACK)
 def acknowledge_deepseek_mutations(transaction_ids: list[str]) -> str:
@@ -245,15 +229,12 @@ def _json(payload: dict) -> str:
     return json.dumps(payload, ensure_ascii=False, indent=2)
 
 
-def _load_config(
-    profile: ExecutionProfile = CODING_PROFILE,
-    model: Literal["flash", "pro"] = "flash",
-) -> Config:
+def _load_config(profile: ExecutionProfile = CODING_PROFILE, model: ModelChoice = "flash") -> Config:
     if _deepseek_mode() == "off":
         raise JobError("DeepSeek delegation is disabled (DEEPSEEK_MODE=off)")
     try:
         config = configure_delegation(Config.load(), profile)
-        config.model = _resolve_model(model)
+        config.model = resolve_model(model)
         return config
     except JobError:
         raise
@@ -283,7 +264,6 @@ def _consume_cancelled_worker(worker: asyncio.Task) -> None:
         worker.exception()
     except BaseException:
         pass
-
 
 async def _run_sync_cancellable(full_task: str, config: Config) -> dict:
     cancel_event = Event()
@@ -317,13 +297,7 @@ async def _run_sync_cancellable(full_task: str, config: Config) -> dict:
                 raise MutationOutcomeCancelled(message, tuple(records)) from None
         raise
 
-
-async def _delegate(
-    task: str,
-    context: str,
-    profile: ExecutionProfile,
-    model: Literal["flash", "pro"],
-) -> str:
+async def _delegate(task: str, context: str, profile: ExecutionProfile, model: ModelChoice) -> str:
     try:
         config, full_task = _prepare_sync_request(task, context, profile, model)
     except JobError as e:
@@ -348,33 +322,18 @@ async def _delegate(
     _record_usage(len(task), result)
     return _format_sync_result(result)
 
-
 @mcp.tool(annotations=_AGENT_EXECUTION)
-async def delegate_to_deepseek(
-    task: str,
-    context: str = "",
-    model: Literal["flash", "pro"] = "flash",
-) -> str:
+async def delegate_to_deepseek(task: str, context: str = "", model: ModelChoice = "flash") -> str:
     """Run a full coding delegation; Flash is default, Pro is for hard tasks."""
     return await _delegate(task, context, CODING_PROFILE, model)
 
-
 @mcp.tool(annotations=_READONLY_AGENT_EXECUTION)
-async def delegate_to_deepseek_readonly(
-    task: str,
-    context: str = "",
-    model: Literal["flash", "pro"] = "flash",
-) -> str:
+async def delegate_to_deepseek_readonly(task: str, context: str = "", model: ModelChoice = "flash") -> str:
     """Run pure file analysis; Flash is default, Pro is for hard tasks."""
     return await _delegate(task, context, READONLY_PROFILE, model)
 
 
-def _prepare_sync_request(
-    task: str,
-    context: str,
-    profile: ExecutionProfile,
-    model: Literal["flash", "pro"] = "flash",
-) -> tuple[Config, str]:
+def _prepare_sync_request(task: str, context: str, profile: ExecutionProfile, model: ModelChoice = "flash") -> tuple[Config, str]:
     if _deepseek_mode() == "off":
         raise JobError(
             "DeepSeek delegation is disabled (DEEPSEEK_MODE=off). "
@@ -409,12 +368,7 @@ def _log_sync_completion(result: dict) -> None:
     )
 
 
-def _start_delegation(
-    task: str,
-    context: str,
-    profile: ExecutionProfile,
-    model: Literal["flash", "pro"],
-) -> str:
+def _start_delegation(task: str, context: str, profile: ExecutionProfile, model: ModelChoice) -> str:
     try:
         payload = job_manager.start(task, context, _load_config(profile, model))
     except JobError as e:
@@ -422,26 +376,15 @@ def _start_delegation(
     logger.info("Background DeepSeek job started: %s model=%s", payload["job_id"], model)
     return _json({"ok": True, **payload})
 
-
 @mcp.tool(annotations=_AGENT_EXECUTION)
-def start_deepseek(
-    task: str,
-    context: str = "",
-    model: Literal["flash", "pro"] = "flash",
-) -> str:
+def start_deepseek(task: str, context: str = "", model: ModelChoice = "flash") -> str:
     """Start a coding job; Flash is default, Pro is for hard tasks."""
     return _start_delegation(task, context, CODING_PROFILE, model)
 
-
 @mcp.tool(annotations=_READONLY_AGENT_EXECUTION)
-def start_deepseek_readonly(
-    task: str,
-    context: str = "",
-    model: Literal["flash", "pro"] = "flash",
-) -> str:
+def start_deepseek_readonly(task: str, context: str = "", model: ModelChoice = "flash") -> str:
     """Start a read-only job; Flash is default, Pro is for hard tasks."""
     return _start_delegation(task, context, READONLY_PROFILE, model)
-
 
 @mcp.tool(annotations=_READ_ONLY)
 def get_deepseek_status(job_id: str) -> str:
@@ -451,7 +394,6 @@ def get_deepseek_status(job_id: str) -> str:
     except JobError as e:
         return _json({"ok": False, "error": str(e)})
     return _json({"ok": True, **payload})
-
 
 @mcp.tool(annotations=_AGENT_CONTROL)
 def send_deepseek_message(job_id: str, message: str) -> str:
@@ -467,7 +409,6 @@ def send_deepseek_message(job_id: str, message: str) -> str:
     logger.info("Queued steering message for DeepSeek job %s", job_id)
     return _json({"ok": True, **payload})
 
-
 @mcp.tool(annotations=_LOCAL_CANCELLATION)
 def cancel_deepseek(job_id: str) -> str:
     """Request cancellation of a running DeepSeek background job.
@@ -481,7 +422,6 @@ def cancel_deepseek(job_id: str) -> str:
         return _json({"ok": False, "error": str(e)})
     logger.info("Cancellation requested for DeepSeek job %s", job_id)
     return _json({"ok": True, **payload})
-
 
 @mcp.tool(annotations=_RESULT_WITH_BOOKKEEPING)
 def get_deepseek_result(job_id: str) -> str:

--- a/src/deepseek_mcp/server.py
+++ b/src/deepseek_mcp/server.py
@@ -18,6 +18,7 @@ import stat
 import sys
 from pathlib import Path
 from threading import Event, Lock
+from typing import Literal
 
 # Windows defaults to ProactorEventLoop, which can deadlock with stdio subprocesses.
 # Switch before importing/starting FastMCP.
@@ -45,12 +46,26 @@ from .transaction_recovery import (
 )
 
 _VALID_MODES = frozenset({"auto", "off"})
+_MODEL_IDS = {
+    "flash": "deepseek-v4-flash",
+    "pro": "deepseek-v4-pro",
+}
+
 
 def _deepseek_mode() -> str:
     value = os.getenv("DEEPSEEK_MODE", "auto")
     if value not in _VALID_MODES:
         raise JobError("DEEPSEEK_MODE must be exactly 'auto' or 'off'")
     return value
+
+
+def _resolve_model(model: str) -> str:
+    try:
+        return _MODEL_IDS[model]
+    except KeyError:
+        raise JobError("model must be exactly 'flash' or 'pro'") from None
+
+
 logger = logging.getLogger(__name__)
 _PACKAGE_LOGGER = logging.getLogger("deepseek_mcp")
 _NULL_LOG_HANDLER = logging.NullHandler()
@@ -200,6 +215,7 @@ def get_deepseek_recovery() -> str:
         return _json({"ok": False, "error": str(error)})
     return _json({"ok": True, "pending": records, "count": len(records)})
 
+
 @mcp.tool(annotations=_RECOVERY_ACK)
 def acknowledge_deepseek_mutations(transaction_ids: list[str]) -> str:
     """Acknowledge exact transaction IDs after the host verifies their files."""
@@ -210,6 +226,7 @@ def acknowledge_deepseek_mutations(transaction_ids: list[str]) -> str:
     except (RuntimeError, TransactionRecoveryError) as error:
         return _json({"ok": False, "error": str(error)})
     return _json({"ok": True, "acknowledged": removed, "pending": pending})
+
 
 def _shorten_path(p: Path) -> str:
     """Shorten long paths for compact ping output."""
@@ -227,11 +244,19 @@ def _shorten_path(p: Path) -> str:
 def _json(payload: dict) -> str:
     return json.dumps(payload, ensure_ascii=False, indent=2)
 
-def _load_config(profile: ExecutionProfile = CODING_PROFILE) -> Config:
+
+def _load_config(
+    profile: ExecutionProfile = CODING_PROFILE,
+    model: Literal["flash", "pro"] = "flash",
+) -> Config:
     if _deepseek_mode() == "off":
         raise JobError("DeepSeek delegation is disabled (DEEPSEEK_MODE=off)")
     try:
-        return configure_delegation(Config.load(), profile)
+        config = configure_delegation(Config.load(), profile)
+        config.model = _resolve_model(model)
+        return config
+    except JobError:
+        raise
     except Exception as e:
         raise JobError(f"deepseek-mcp not configured: {e}") from e
 
@@ -258,6 +283,7 @@ def _consume_cancelled_worker(worker: asyncio.Task) -> None:
         worker.exception()
     except BaseException:
         pass
+
 
 async def _run_sync_cancellable(full_task: str, config: Config) -> dict:
     cancel_event = Event()
@@ -291,9 +317,15 @@ async def _run_sync_cancellable(full_task: str, config: Config) -> dict:
                 raise MutationOutcomeCancelled(message, tuple(records)) from None
         raise
 
-async def _delegate(task: str, context: str, profile: ExecutionProfile) -> str:
+
+async def _delegate(
+    task: str,
+    context: str,
+    profile: ExecutionProfile,
+    model: Literal["flash", "pro"],
+) -> str:
     try:
-        config, full_task = _prepare_sync_request(task, context, profile)
+        config, full_task = _prepare_sync_request(task, context, profile, model)
     except JobError as e:
         return str(e)
     try:
@@ -318,19 +350,30 @@ async def _delegate(task: str, context: str, profile: ExecutionProfile) -> str:
 
 
 @mcp.tool(annotations=_AGENT_EXECUTION)
-async def delegate_to_deepseek(task: str, context: str = "") -> str:
-    """Run a full coding delegation with trusted-host Bash."""
-    return await _delegate(task, context, CODING_PROFILE)
+async def delegate_to_deepseek(
+    task: str,
+    context: str = "",
+    model: Literal["flash", "pro"] = "flash",
+) -> str:
+    """Run a full coding delegation; Flash is default, Pro is for hard tasks."""
+    return await _delegate(task, context, CODING_PROFILE, model)
 
 
 @mcp.tool(annotations=_READONLY_AGENT_EXECUTION)
-async def delegate_to_deepseek_readonly(task: str, context: str = "") -> str:
-    """Run a pure file-analysis delegation without command execution."""
-    return await _delegate(task, context, READONLY_PROFILE)
+async def delegate_to_deepseek_readonly(
+    task: str,
+    context: str = "",
+    model: Literal["flash", "pro"] = "flash",
+) -> str:
+    """Run pure file analysis; Flash is default, Pro is for hard tasks."""
+    return await _delegate(task, context, READONLY_PROFILE, model)
 
 
 def _prepare_sync_request(
-    task: str, context: str, profile: ExecutionProfile,
+    task: str,
+    context: str,
+    profile: ExecutionProfile,
+    model: Literal["flash", "pro"] = "flash",
 ) -> tuple[Config, str]:
     if _deepseek_mode() == "off":
         raise JobError(
@@ -338,7 +381,7 @@ def _prepare_sync_request(
             "Continue the task yourself in the main conversation."
         )
     try:
-        config = _load_config(profile)
+        config = _load_config(profile, model)
     except JobError:
         raise
     except Exception as error:
@@ -348,7 +391,8 @@ def _prepare_sync_request(
     except JobError as error:
         raise JobError(f"ERROR: invalid DeepSeek delegation input: {error}") from None
     logger.info(
-        "delegate_to_deepseek invoked. Task length=%d, context length=%d",
+        "delegate_to_deepseek invoked. model=%s task length=%d, context length=%d",
+        model,
         len(task),
         len(context),
     )
@@ -365,25 +409,38 @@ def _log_sync_completion(result: dict) -> None:
     )
 
 
-def _start_delegation(task: str, context: str, profile: ExecutionProfile) -> str:
+def _start_delegation(
+    task: str,
+    context: str,
+    profile: ExecutionProfile,
+    model: Literal["flash", "pro"],
+) -> str:
     try:
-        payload = job_manager.start(task, context, _load_config(profile))
+        payload = job_manager.start(task, context, _load_config(profile, model))
     except JobError as e:
         return _json({"ok": False, "error": str(e)})
-    logger.info("Background DeepSeek job started: %s", payload["job_id"])
+    logger.info("Background DeepSeek job started: %s model=%s", payload["job_id"], model)
     return _json({"ok": True, **payload})
 
 
 @mcp.tool(annotations=_AGENT_EXECUTION)
-def start_deepseek(task: str, context: str = "") -> str:
-    """Start a steerable full coding job with trusted-host Bash."""
-    return _start_delegation(task, context, CODING_PROFILE)
+def start_deepseek(
+    task: str,
+    context: str = "",
+    model: Literal["flash", "pro"] = "flash",
+) -> str:
+    """Start a coding job; Flash is default, Pro is for hard tasks."""
+    return _start_delegation(task, context, CODING_PROFILE, model)
 
 
 @mcp.tool(annotations=_READONLY_AGENT_EXECUTION)
-def start_deepseek_readonly(task: str, context: str = "") -> str:
-    """Start a steerable pure file-analysis job."""
-    return _start_delegation(task, context, READONLY_PROFILE)
+def start_deepseek_readonly(
+    task: str,
+    context: str = "",
+    model: Literal["flash", "pro"] = "flash",
+) -> str:
+    """Start a read-only job; Flash is default, Pro is for hard tasks."""
+    return _start_delegation(task, context, READONLY_PROFILE, model)
 
 
 @mcp.tool(annotations=_READ_ONLY)

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import inspect
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from deepseek_mcp import server
+from deepseek_mcp.config import Config
+from deepseek_mcp.execution_profile import CODING_PROFILE, READONLY_PROFILE
+from deepseek_mcp.job_manager import JobError
+
+
+class ModelSelectionTests(unittest.TestCase):
+    def _config(self, workspace: Path) -> Config:
+        return Config("sk-test", workspace, allowed_tools=["Read"])
+
+    def test_public_delegation_tools_default_to_flash(self) -> None:
+        for tool in (
+            server.delegate_to_deepseek,
+            server.delegate_to_deepseek_readonly,
+            server.start_deepseek,
+            server.start_deepseek_readonly,
+        ):
+            parameter = inspect.signature(tool).parameters["model"]
+            self.assertEqual(parameter.default, "flash")
+
+    def test_model_aliases_are_exact(self) -> None:
+        self.assertEqual(server._resolve_model("flash"), "deepseek-v4-flash")
+        self.assertEqual(server._resolve_model("pro"), "deepseek-v4-pro")
+        with self.assertRaisesRegex(JobError, "flash.*pro"):
+            server._resolve_model("other")
+
+    def test_load_config_overrides_legacy_config_model_with_flash_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = self._config(Path(tmpdir))
+            config.model = "legacy-configured-model"
+            with (
+                patch.object(server.Config, "load", return_value=config),
+                patch.object(server, "configure_delegation", side_effect=lambda cfg, _profile: cfg),
+            ):
+                loaded = server._load_config(CODING_PROFILE)
+
+        self.assertIs(loaded, config)
+        self.assertEqual(loaded.model, "deepseek-v4-flash")
+
+    def test_load_config_can_select_pro(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = self._config(Path(tmpdir))
+            with (
+                patch.object(server.Config, "load", return_value=config),
+                patch.object(server, "configure_delegation", side_effect=lambda cfg, _profile: cfg),
+            ):
+                loaded = server._load_config(READONLY_PROFILE, "pro")
+
+        self.assertEqual(loaded.model, "deepseek-v4-pro")
+
+    def test_background_job_receives_selected_model_once(self) -> None:
+        manager = Mock()
+        manager.start.return_value = {"job_id": "job-1", "status": "running"}
+        config = Mock(model="deepseek-v4-pro")
+        with (
+            patch.object(server, "job_manager", manager),
+            patch.object(server, "_load_config", return_value=config) as load_config,
+        ):
+            payload = server.start_deepseek("hard task", model="pro")
+
+        self.assertIn('"ok": true', payload)
+        load_config.assert_called_once_with(CODING_PROFILE, "pro")
+        manager.start.assert_called_once_with("hard task", "", config)
+        self.assertNotIn("model", inspect.signature(server.send_deepseek_message).parameters)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(ROOT / "src"))
 from deepseek_mcp import server
 from deepseek_mcp.config import Config, DEFAULT_MODEL
 from deepseek_mcp.execution_profile import CODING_PROFILE, READONLY_PROFILE
-from deepseek_mcp.job_manager import JobError
+from deepseek_mcp.model_selection import resolve_model
 
 
 class ModelSelectionTests(unittest.TestCase):
@@ -32,10 +32,10 @@ class ModelSelectionTests(unittest.TestCase):
             self.assertEqual(parameter.default, "flash")
 
     def test_model_aliases_are_exact(self) -> None:
-        self.assertEqual(server._resolve_model("flash"), "deepseek-v4-flash")
-        self.assertEqual(server._resolve_model("pro"), "deepseek-v4-pro")
-        with self.assertRaisesRegex(JobError, "flash.*pro"):
-            server._resolve_model("other")
+        self.assertEqual(resolve_model("flash"), "deepseek-v4-flash")
+        self.assertEqual(resolve_model("pro"), "deepseek-v4-pro")
+        with self.assertRaisesRegex(ValueError, "flash.*pro"):
+            resolve_model("other")
 
     def test_load_config_overrides_legacy_config_model_with_flash_by_default(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -11,7 +11,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 from deepseek_mcp import server
-from deepseek_mcp.config import Config
+from deepseek_mcp.config import Config, DEFAULT_MODEL
 from deepseek_mcp.execution_profile import CODING_PROFILE, READONLY_PROFILE
 from deepseek_mcp.job_manager import JobError
 
@@ -20,7 +20,8 @@ class ModelSelectionTests(unittest.TestCase):
     def _config(self, workspace: Path) -> Config:
         return Config("sk-test", workspace, allowed_tools=["Read"])
 
-    def test_public_delegation_tools_default_to_flash(self) -> None:
+    def test_config_and_public_tools_default_to_flash(self) -> None:
+        self.assertEqual(DEFAULT_MODEL, "deepseek-v4-flash")
         for tool in (
             server.delegate_to_deepseek,
             server.delegate_to_deepseek_readonly,

--- a/tests/test_server_annotations.py
+++ b/tests/test_server_annotations.py
@@ -590,7 +590,7 @@ server._record_usage(1, {
             )
             self.assertEqual(actual, hints, name)
 
-    def test_legacy_public_tool_schemas_remain_exactly_compatible(self) -> None:
+    def test_public_tool_schemas_add_only_flash_pro_model_selector(self) -> None:
         tools = {tool.name: tool for tool in asyncio.run(mcp.list_tools())}
 
         self.assertEqual(
@@ -601,22 +601,35 @@ server._record_usage(1, {
                 "type": "object",
             },
         )
-        self.assertEqual(
-            tools["delegate_to_deepseek"].inputSchema,
-            {
-                "properties": {
-                    "context": {
-                        "default": "",
-                        "title": "Context",
-                        "type": "string",
+        model = {
+            "default": "flash",
+            "enum": ["flash", "pro"],
+            "title": "Model",
+            "type": "string",
+        }
+        for name in (
+            "delegate_to_deepseek",
+            "delegate_to_deepseek_readonly",
+            "start_deepseek",
+            "start_deepseek_readonly",
+        ):
+            self.assertEqual(
+                tools[name].inputSchema,
+                {
+                    "properties": {
+                        "task": {"title": "Task", "type": "string"},
+                        "context": {
+                            "default": "",
+                            "title": "Context",
+                            "type": "string",
+                        },
+                        "model": model,
                     },
-                    "task": {"title": "Task", "type": "string"},
+                    "required": ["task"],
+                    "title": f"{name}Arguments",
+                    "type": "object",
                 },
-                "required": ["task"],
-                "title": "delegate_to_deepseekArguments",
-                "type": "object",
-            },
-        )
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a `model` argument to all four delegation entry points
- default omitted `model` to `flash`
- map `flash` -> `deepseek-v4-flash` and `pro` -> `deepseek-v4-pro`
- keep background jobs pinned to the model selected at start; steering cannot change it
- retain the legacy config `model` key for compatibility, but per-call selection overrides it
- add contract tests locking the default and model mapping

## Compatibility
Existing MCP calls that omit `model` remain valid. Their runtime default intentionally changes from the previous configured/default Pro behavior to Flash, per product policy.

## Scope
No changes to the agent loop, provider retry logic, Bash execution, mutation journal, workspace lease, or MCP transport.