### PR TITLE
fix: make Flash/Pro model profiles configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,10 @@ No third-party proxy or cloud relay is introduced by this project. Delegated pro
 {
   "api_key": "sk-...",
   "flash": "deepseek-v4-flash",
+  "flash_reasoning_effort": "high",
   "pro": "deepseek-v4-pro",
+  "pro_reasoning_effort": "high",
+  "_reasoning_effort_options": ["none", "low", "high", "max"],
   "max_turns": 50,
   "max_run_seconds": 18000,
   "allowed_tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "NotebookEdit"]
@@ -285,6 +288,14 @@ profiles. You can change these strings when DeepSeek publishes a new model
 revision, or when a compatible endpoint uses different model names, without
 changing how Claude/Codex calls the MCP tools. The public tool argument remains
 only `model="flash"` or `model="pro"`.
+
+`flash_reasoning_effort` and `pro_reasoning_effort` accept `none`, `low`, `high`,
+or `max`. `none` disables thinking; the other values explicitly enable thinking
+at that effort. `_reasoning_effort_options` is only an in-file hint and is ignored
+at runtime. If an effort field is absent, deepseek-mcp leaves thinking controls
+unspecified for that slot so the provider's existing default applies; this keeps
+older configs and OpenAI-compatible gateways compatible. New installer-generated
+configs explicitly set both slots to `high`.
 
 For upgrade compatibility, a legacy single `model` field is still accepted when
 `flash` and `pro` are absent; its value is used for both slots. Do not combine

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ result back. Token savings are end-to-end.
 - **MCP server** (Python, stdio transport)
 - **Coding and read-only delegation**: `delegate_to_deepseek` / `delegate_to_deepseek_readonly`
 - **Steerable background jobs**: `start_deepseek` / `start_deepseek_readonly` plus shared controls
+- **Flash / Pro model routing**: host chooses a stable profile; users control the actual provider model IDs in config
 - **Local DeepSeek agent loop** (`agent_loop.py`) with OpenAI-compatible function calling
 - **Fixed capability APIs**: coding gets Read / Write / Edit / Bash / Glob / Grep / NotebookEdit; read-only gets Read / Glob / Grep
 - **Bash execution**: bounded credential-isolated trusted-host commands through the tool-child boundary
@@ -110,11 +111,11 @@ result back. Token savings are end-to-end.
 
 ## Compatibility
 
-The existing MCP entry points `ping()` and
-`delegate_to_deepseek(task, context="")` keep their input schema; the
-background-job and recovery tools are additive. This is input-schema compatible,
-but mutation-capable legacy hosts must adopt the additive recovery query/verify/ack
-handshake before starting another delegation; read-only use needs no change.
+The four delegation entry points accept one additive optional argument,
+`model="flash" | "pro"`. Existing calls that omit it remain valid and now default
+to the Flash profile. Background-job and recovery tools remain additive.
+Mutation-capable legacy hosts must adopt the recovery query/verify/ack handshake
+before starting another delegation; read-only use needs no change.
 Clients should not parse health/error text byte-for-byte because diagnostics are now more specific. Provider calls still
 use DeepSeek's [OpenAI-compatible Chat Completions API](https://api-docs.deepseek.com/api/create-chat-completion/).
 Local Python module signatures are implementation details rather than a stable
@@ -171,9 +172,15 @@ clearly read-only, choose coding.
 Use a synchronous API when the task can run to completion without mid-flight
 intervention. The MCP request remains open until DeepSeek finishes:
 
-- `delegate_to_deepseek(task, context)` for coding, Bash, tests, or any task
-  that might write the workspace.
-- `delegate_to_deepseek_readonly(task, context)` for static file analysis only.
+- `delegate_to_deepseek(task, context, model="flash")` for coding, Bash, tests,
+  or any task that might write the workspace.
+- `delegate_to_deepseek_readonly(task, context, model="flash")` for static file
+  analysis only.
+
+`model` is optional and accepts only `flash` or `pro`. Omit it for normal work;
+select `pro` explicitly for difficult debugging, architecture-level reasoning,
+or when Flash has already proved insufficient. The host never passes a provider
+model ID directly.
 
 ### Steerable background delegation
 
@@ -181,7 +188,7 @@ For longer tasks that may need new instructions or cancellation, choose the
 matching background API, then use the same controls for either job type:
 
 ```text
-start_deepseek(task, context) / start_deepseek_readonly(task, context) -> job_id
+start_deepseek(task, context, model="flash") / start_deepseek_readonly(task, context, model="flash") -> job_id
 send_deepseek_message(job_id, message)
 get_deepseek_status(job_id)
 cancel_deepseek(job_id)
@@ -190,8 +197,9 @@ get_deepseek_result(job_id)
 
 Either `start_*` API returns quickly while the DeepSeek agent continues in a
 background worker. Steering changes only the task instruction: it cannot change
-the job's fixed tools or Bash availability. Cancellation wakes retry backoff and
-promptly terminates an in-flight provider or local-tool subprocess.
+the job's fixed tools, Bash availability, or selected model profile. Cancellation
+wakes retry backoff and promptly terminates an in-flight provider or local-tool
+subprocess.
 
 If a readonly job later needs a command or workspace mutation, cancel or finish
 it, then create a new coding job with `start_deepseek`; steering cannot upgrade
@@ -224,7 +232,7 @@ rolls back workspace files.
 ### Claude Code helpers
 
 - `delegate_to_deepseek` / `delegate_to_deepseek_readonly` — Claude selects the
-  matching fixed capability for coding or static analysis
+  matching fixed capability and Flash/Pro profile
 - `/ds <task>` — force synchronous coding delegation
 - `DEEPSEEK_MODE=off claude` — start one session with DeepSeek disabled
 
@@ -264,12 +272,23 @@ No third-party proxy or cloud relay is introduced by this project. Delegated pro
 ```json
 {
   "api_key": "sk-...",
-  "model": "deepseek-v4-pro",
+  "flash": "deepseek-v4-flash",
+  "pro": "deepseek-v4-pro",
   "max_turns": 50,
   "max_run_seconds": 18000,
   "allowed_tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "NotebookEdit"]
 }
 ```
+
+`flash` and `pro` are the provider model IDs behind the two stable MCP routing
+profiles. You can change these strings when DeepSeek publishes a new model
+revision, or when a compatible endpoint uses different model names, without
+changing how Claude/Codex calls the MCP tools. The public tool argument remains
+only `model="flash"` or `model="pro"`.
+
+For upgrade compatibility, a legacy single `model` field is still accepted when
+`flash` and `pro` are absent; its value is used for both slots. Do not combine
+legacy `model` with the new `flash` / `pro` fields.
 
 `allowed_tools` is retained for configuration compatibility and validation. It
 does not select capabilities for a delegation: each MCP API applies its own

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -269,7 +269,10 @@ max_retries=0
 {
   "api_key": "sk-...",
   "flash": "deepseek-v4-flash",
+  "flash_reasoning_effort": "high",
   "pro": "deepseek-v4-pro",
+  "pro_reasoning_effort": "high",
+  "_reasoning_effort_options": ["none", "low", "high", "max"],
   "max_turns": 50,
   "max_run_seconds": 18000,
   "allowed_tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "NotebookEdit"]
@@ -279,6 +282,13 @@ max_retries=0
 `flash` 和 `pro` 是两个稳定 MCP 路由槽位背后的真实 provider 模型名。DeepSeek 后续升级
 到新版本，或者兼容 API 端点使用不同模型名时，用户只需要修改这里的字符串，不需要改变
 Claude/Codex 的 MCP 调用方式；公共参数始终只传 `model="flash"` 或 `model="pro"`。
+
+`flash_reasoning_effort` 和 `pro_reasoning_effort` 可配置为 `none`、`low`、`high`、`max`。
+`none` 表示关闭 thinking；其余三档会显式开启 thinking 并使用对应 effort。
+`_reasoning_effort_options` 只是配置文件里的提示字段，运行时忽略。若某个 effort 字段缺失，
+deepseek-mcp 不会向该槽位请求附加 thinking/reasoning 参数，而是沿用 provider 原有默认行为；
+这样可以保持旧配置和 OpenAI-compatible 网关的请求形态。新安装器生成的配置会显式把两个
+槽位都设为 `high`。
 
 为了兼容旧版本，当 `flash` / `pro` 都不存在时，旧的单 `model` 字段仍然可以读取，并会
 同时映射到两个槽位。不要把旧 `model` 和新 `flash` / `pro` 混用。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -95,6 +95,7 @@ Codex 和其它 MCP 客户端见下方安装说明。
 - **MCP server**（Python，stdio）
 - **coding 与只读委派**：`delegate_to_deepseek` / `delegate_to_deepseek_readonly`
 - **后台可控任务**：`start_deepseek` / `start_deepseek_readonly` 与共用控制 API
+- **Flash / Pro 模型路由**：主 Agent 只选稳定档位，用户在配置里控制真实 provider 模型名
 - **DeepSeek 本地 agent loop**（`agent_loop.py`）
 - **固定 capability API**：coding 为 Read / Write / Edit / Bash / Glob / Grep / NotebookEdit；只读为 Read / Glob / Grep
 - **Bash 执行**：通过 tool-child 边界运行有界且隔离凭证的 `trusted_host`
@@ -106,11 +107,10 @@ Codex 和其它 MCP 客户端见下方安装说明。
 
 ## 兼容性
 
-既有 MCP 入口 `ping()` 与 `delegate_to_deepseek(task, context="")` 保持
-输入 schema；后台任务与恢复工具都是增量新增。这保证输入 schema 兼容，
-但会写文件的老宿主必须接入新增的“恢复查询 → 文件核验 → 精确确认”流程，
-才能继续下一次委派；只读用法无需调整。健康检查和错误文本包含了更明确的
-诊断信息，不承诺逐字节不变。Provider 仍使用 DeepSeek 的
+四个委派入口新增一个可选参数 `model="flash" | "pro"`。旧调用不传该参数时仍然合法，
+并默认选择 Flash 档。后台任务和恢复工具仍然是增量能力。会写文件的老宿主必须接入
+“恢复查询 → 文件核验 → 精确确认”流程，才能继续下一次委派；只读用法无需调整。
+健康检查和错误文本包含更明确的诊断信息，不承诺逐字节不变。Provider 仍使用 DeepSeek 的
 [OpenAI-compatible Chat Completions API](https://api-docs.deepseek.com/api/create-chat-completion/)。
 本地 Python 模块签名属于实现细节，不作为稳定公共 API。
 
@@ -162,9 +162,13 @@ coding。
 任务不需要中途干预时，按能力直接使用同步 API：
 
 ```text
-delegate_to_deepseek(task, context)
-delegate_to_deepseek_readonly(task, context)
+delegate_to_deepseek(task, context, model="flash")
+delegate_to_deepseek_readonly(task, context, model="flash")
 ```
+
+`model` 是可选参数，只允许 `flash` / `pro`。普通任务省略即可，默认 Flash；复杂 debugging、
+架构级推理、困难多文件推理，或 Flash 已明显不足时才显式选择 Pro。主 Agent 不直接传真实
+provider 模型名。
 
 前者用于 coding、Bash、测试或任何可能写工作区的任务；后者只用于静态文件分析。
 MCP 请求会一直保持到 DeepSeek 完成。
@@ -175,14 +179,14 @@ MCP 请求会一直保持到 DeepSeek 完成。
 job 都使用同一组控制接口：
 
 ```text
-start_deepseek(task, context) / start_deepseek_readonly(task, context) -> job_id
+start_deepseek(task, context, model="flash") / start_deepseek_readonly(task, context, model="flash") -> job_id
 send_deepseek_message(job_id, message)
 get_deepseek_status(job_id)
 cancel_deepseek(job_id)
 get_deepseek_result(job_id)
 ```
 
-两个 `start_*` API 都会很快返回，DeepSeek 在后台 worker 中继续执行，因此同一个 MCP session 后续还能继续发送控制请求。steering 只能更新任务指令，不能改变该 job 已冻结的工具或 Bash 可用性。
+两个 `start_*` API 都会很快返回，DeepSeek 在后台 worker 中继续执行，因此同一个 MCP session 后续还能继续发送控制请求。steering 只能更新任务指令，不能改变该 job 已冻结的工具、Bash 可用性或模型档位。
 
 如果 readonly job 后续需要执行命令或修改工作区，应取消或结束它，再用
 `start_deepseek` 新建 coding job；steering 不能升级既有 readonly job。
@@ -212,7 +216,7 @@ DeepSeek API key，也不会删除或回滚工作区文件。
 
 ### Claude Code 辅助入口
 
-- `delegate_to_deepseek` —— 合适时自动调用
+- `delegate_to_deepseek` / `delegate_to_deepseek_readonly` —— Claude 自动选择 capability 与 Flash/Pro 档位
 - `/ds <task>` —— 强制同步委派
 - `pure` —— 本次 Claude 会话禁用 DeepSeek
 
@@ -264,12 +268,20 @@ max_retries=0
 ```json
 {
   "api_key": "sk-...",
-  "model": "deepseek-v4-pro",
+  "flash": "deepseek-v4-flash",
+  "pro": "deepseek-v4-pro",
   "max_turns": 50,
   "max_run_seconds": 18000,
   "allowed_tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "NotebookEdit"]
 }
 ```
+
+`flash` 和 `pro` 是两个稳定 MCP 路由槽位背后的真实 provider 模型名。DeepSeek 后续升级
+到新版本，或者兼容 API 端点使用不同模型名时，用户只需要修改这里的字符串，不需要改变
+Claude/Codex 的 MCP 调用方式；公共参数始终只传 `model="flash"` 或 `model="pro"`。
+
+为了兼容旧版本，当 `flash` / `pro` 都不存在时，旧的单 `model` 字段仍然可以读取，并会
+同时映射到两个槽位。不要把旧 `model` 和新 `flash` / `pro` 混用。
 
 `allowed_tools` 为兼容已有配置和校验而保留；它不用于为某次委派选择能力。
 MCP API 会在加载配置后应用各自固定的 profile。

--- a/adapters/codex/install.sh
+++ b/adapters/codex/install.sh
@@ -201,7 +201,10 @@ if [ ! -f "$CONFIG_FILE" ]; then
 {
   "api_key": "PASTE_YOUR_DEEPSEEK_KEY_HERE",
   "flash": "deepseek-v4-flash",
+  "flash_reasoning_effort": "high",
   "pro": "deepseek-v4-pro",
+  "pro_reasoning_effort": "high",
+  "_reasoning_effort_options": ["none", "low", "high", "max"],
   "max_turns": 50,
   "max_run_seconds": 18000,
   "allowed_tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "NotebookEdit"]

--- a/adapters/codex/install.sh
+++ b/adapters/codex/install.sh
@@ -200,7 +200,8 @@ if [ ! -f "$CONFIG_FILE" ]; then
     "${PYTHON_CMD[@]}" "$PATH_GUARD" write-exclusive "$CONFIG_FILE" <<'EOF'
 {
   "api_key": "PASTE_YOUR_DEEPSEEK_KEY_HERE",
-  "model": "deepseek-v4-pro",
+  "flash": "deepseek-v4-flash",
+  "pro": "deepseek-v4-pro",
   "max_turns": 50,
   "max_run_seconds": 18000,
   "allowed_tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "NotebookEdit"]

--- a/commands/ds.md
+++ b/commands/ds.md
@@ -8,12 +8,17 @@ description: 显式派工给 DeepSeek sub-agent（绕过 Claude 自动决策）�
 `/ds` 固定调用完整 coding API；明确只做静态文件分析的任务应由主 Agent 选择
 `delegate_to_deepseek_readonly`。
 
+模型选择遵循 `delegate-to-deepseek` skill：默认不传 `model`，即使用 Flash；只有任务明显属于复杂 debugging、架构级推理、困难多文件推理，或 Flash 已明显不足时才传 `model="pro"`。Flash 约为 Sonnet/Terra 档，Pro 约为 Opus/Sol 档；这是路由参考，不是绝对等价声明。
+
+`flash/pro` 只是稳定路由槽位。不要把真实 provider 模型名传进 MCP；实际模型名由用户的 `~/.deepseek-mcp/config.json` 中 `flash` / `pro` 字段决定。
+
 ## 你要做的
 
-1. 按 `delegate-to-deepseek` skill 的准则准备 `task` 和 `context`：
+1. 按 `delegate-to-deepseek` skill 的准则准备 `task`、`context` 和必要时的 `model`：
    - 用 Glob / LS 收集涉及的文件路径
    - 摘要项目约定（命名规则、输出 schema、边界）
    - 写明成功标准
+   - 普通任务保持默认 Flash；困难任务才显式选择 Pro
 
 2. 调用 `mcp__deepseek__delegate_to_deepseek` 工具，把用户的请求当作 task 传入：
 
@@ -29,5 +34,7 @@ description: 显式派工给 DeepSeek sub-agent（绕过 Claude 自动决策）�
 ## 不要做的
 
 - ❌ 不要在调用前问用户"你确定要派吗" —— 用户敲 `/ds` 已经是明确指令
+- ❌ 不要因为 Pro 可用就默认选择 Pro
+- ❌ 不要把真实 provider 模型名传给 `model` 参数
 - ❌ 不要在工具返回 ERROR 时直接放弃 —— 按 skill 的 fallback 策略重试或接管
 - ❌ 不要把 API key / 凭证塞进 task / context

--- a/docs/model-selection.md
+++ b/docs/model-selection.md
@@ -7,17 +7,22 @@ The public delegation API supports exactly two stable model profiles:
 
 All four delegation entry points default to `model="flash"` when the argument is omitted. Use `model="pro"` only when the host decides the task needs the stronger model, for example complex debugging, architecture work, or a retry after Flash is insufficient.
 
-The actual provider model IDs are user-configurable in `~/.deepseek-mcp/config.json`:
+The actual provider model IDs and reasoning effort for each slot are user-configurable in `~/.deepseek-mcp/config.json`:
 
 ```json
 {
   "flash": "deepseek-v4-flash",
-  "pro": "deepseek-v4-pro"
+  "flash_reasoning_effort": "high",
+  "pro": "deepseek-v4-pro",
+  "pro_reasoning_effort": "high",
+  "_reasoning_effort_options": ["none", "low", "high", "max"]
 }
 ```
 
-The strings behind `flash` and `pro` are intentionally not hard-coded in the routing layer. Users can update them when DeepSeek releases new model revisions, or when a compatible API endpoint exposes different model names, without changing the MCP tool API.
+`_reasoning_effort_options` is a documentation hint only and is ignored at runtime. The effective fields are `flash_reasoning_effort` and `pro_reasoning_effort`. Supported values are `none`, `low`, `high`, and `max`; `none` disables thinking, while the other values enable thinking at the selected effort.
 
-A background job keeps the profile and resolved provider model selected when it starts. Steering messages do not change the model of an already-running job.
+The strings behind `flash` and `pro` are intentionally not hard-coded in the routing layer. Users can update them when DeepSeek releases new model revisions, or when a compatible API endpoint exposes different model names, without changing the MCP tool API. The host still passes only `model="flash"` or `model="pro"`; it never sends provider model IDs or reasoning effort values directly.
+
+A background job keeps the profile, resolved provider model, and configured reasoning effort selected when it starts. Steering messages do not change them for an already-running job.
 
 For upgrade compatibility, the legacy single `model` config field is still accepted when `flash` and `pro` are absent. In that case its value is used for both slots. Do not combine legacy `model` with the new `flash` / `pro` fields.

--- a/docs/model-selection.md
+++ b/docs/model-selection.md
@@ -1,12 +1,23 @@
 # DeepSeek model selection
 
-The public delegation API supports exactly two model profiles:
+The public delegation API supports exactly two stable model profiles:
 
-- `flash` -> `deepseek-v4-flash`
-- `pro` -> `deepseek-v4-pro`
+- `flash`
+- `pro`
 
 All four delegation entry points default to `model="flash"` when the argument is omitted. Use `model="pro"` only when the host decides the task needs the stronger model, for example complex debugging, architecture work, or a retry after Flash is insufficient.
 
-A background job keeps the model chosen when it starts. Steering messages do not change the model of an already-running job.
+The actual provider model IDs are user-configurable in `~/.deepseek-mcp/config.json`:
 
-The `model` field in the legacy config remains accepted for compatibility, but public delegation calls select Flash by default and override it with the per-call `flash` / `pro` choice.
+```json
+{
+  "flash": "deepseek-v4-flash",
+  "pro": "deepseek-v4-pro"
+}
+```
+
+The strings behind `flash` and `pro` are intentionally not hard-coded in the routing layer. Users can update them when DeepSeek releases new model revisions, or when a compatible API endpoint exposes different model names, without changing the MCP tool API.
+
+A background job keeps the profile and resolved provider model selected when it starts. Steering messages do not change the model of an already-running job.
+
+For upgrade compatibility, the legacy single `model` config field is still accepted when `flash` and `pro` are absent. In that case its value is used for both slots. Do not combine legacy `model` with the new `flash` / `pro` fields.

--- a/docs/model-selection.md
+++ b/docs/model-selection.md
@@ -21,8 +21,10 @@ The actual provider model IDs and reasoning effort for each slot are user-config
 
 `_reasoning_effort_options` is a documentation hint only and is ignored at runtime. The effective fields are `flash_reasoning_effort` and `pro_reasoning_effort`. Supported values are `none`, `low`, `high`, and `max`; `none` disables thinking, while the other values enable thinking at the selected effort.
 
+Reasoning controls are sent only when the corresponding `*_reasoning_effort` field is explicitly present. If an effort field is absent, deepseek-mcp leaves thinking controls unspecified for that slot so the provider's existing default applies. This preserves the request shape of older configs and OpenAI-compatible gateways. New installer-generated configs explicitly set both slots to `high`.
+
 The strings behind `flash` and `pro` are intentionally not hard-coded in the routing layer. Users can update them when DeepSeek releases new model revisions, or when a compatible API endpoint exposes different model names, without changing the MCP tool API. The host still passes only `model="flash"` or `model="pro"`; it never sends provider model IDs or reasoning effort values directly.
 
-A background job keeps the profile, resolved provider model, and configured reasoning effort selected when it starts. Steering messages do not change them for an already-running job.
+A background job keeps the profile, resolved provider model, and configured reasoning behavior selected when it starts. Steering messages do not change them for an already-running job.
 
 For upgrade compatibility, the legacy single `model` config field is still accepted when `flash` and `pro` are absent. In that case its value is used for both slots. Do not combine legacy `model` with the new `flash` / `pro` fields.

--- a/install.sh
+++ b/install.sh
@@ -332,7 +332,8 @@ if [ ! -f "$CONFIG_FILE" ]; then
     $PYTHON_CMD "$PATH_GUARD" write-exclusive "$CONFIG_FILE" <<EOF
 {
   "api_key": "$escaped_value",
-  "model": "deepseek-v4-pro",
+  "flash": "deepseek-v4-flash",
+  "pro": "deepseek-v4-pro",
   "max_turns": 50,
   "max_run_seconds": 18000,
   "allowed_tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "NotebookEdit"]

--- a/install.sh
+++ b/install.sh
@@ -333,7 +333,10 @@ if [ ! -f "$CONFIG_FILE" ]; then
 {
   "api_key": "$escaped_value",
   "flash": "deepseek-v4-flash",
+  "flash_reasoning_effort": "high",
   "pro": "deepseek-v4-pro",
+  "pro_reasoning_effort": "high",
+  "_reasoning_effort_options": ["none", "low", "high", "max"],
   "max_turns": 50,
   "max_run_seconds": 18000,
   "allowed_tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "NotebookEdit"]

--- a/skills/delegate-to-deepseek/SKILL.md
+++ b/skills/delegate-to-deepseek/SKILL.md
@@ -15,7 +15,7 @@ description: 默认把中等及以下、批量、重复或机械任务作为完�
 - DeepSeek 读取的文件内容会发送到配置的 API endpoint；敏感工作区不得派工。
 - coding 能力固定为 Read / Write / Edit / Bash / Glob / Grep / NotebookEdit；readonly 固定为 Read / Glob / Grep。不得通过 task、steering 或其它参数提权。
 - coding Bash 是受边界约束的 trusted-host Bash，不是操作系统级沙箱。
-- 派工结果必须由主 Agent独立验证，失败由主 Agent 收口。
+- 派工结果必须由主 Agent 独立验证，失败由主 Agent 收口。
 - 出现文件 mutation、取消、断连或 MCP 重启后，先调用 `get_deepseek_recovery()`，核验实际文件，再用精确 transaction IDs 调用 `acknowledge_deepseek_mutations(...)`；未确认前不要重试 mutation delegation。
 
 ## 2. API 选择
@@ -43,7 +43,7 @@ description: 默认把中等及以下、批量、重复或机械任务作为完�
 - **Pro**：困难任务子代理，约 **Opus / Sol 档**。用于复杂 debugging、架构级推理、困难多文件推理，或 Flash 已明显不足后的升级。
 - 没有明确困难信号时保持 Flash；不要因为 Pro 可用就默认 Pro。
 - 主 Agent 只选择 `flash/pro`，不要尝试控制 reasoning effort；thinking 档位由用户配置决定。
-- background job 启动时冻结模型与能力。需要换模型时结束/取消当前 job，再新建 job。
+- background job 启动时冻结模型、reasoning effort 与能力。需要换模型时结束/取消当前 job，再新建 job。
 
 ## 4. 默认派工策略
 
@@ -65,128 +65,61 @@ description: 默认把中等及以下、批量、重复或机械任务作为完�
 
 这些是成本优化启发式，不是绝对限制。主 Agent 对任务边界、失败代价和验证手段有高把握时，可以调整；但不可突破第 1 节的边界。
 
-### 快速判断
-
-| 信号 | 默认行为 |
-|---|---|
-| “写 / 实现 / 补测试 / 批量改 / 翻译 / 提取” | Flash |
-| 普通 review / 静态调查 | readonly Flash |
-| 明显复杂 debug / 架构级推理 | Pro（若决定委派） |
-| Flash 已验证不足 | 新建 Pro 任务 |
-| 极小改动 | 主 Agent 自己做 |
-| “派给 DS” / `/ds` | 强制派，默认 Flash；明显困难可 Pro |
-| “你自己干 / 别派” | 不派 |
-
 ## 5. 派工时机
 
 尽量在主 Agent 大量读取项目源码之前决定是否派工，避免主 Agent 和 DeepSeek 重复加载同一批上下文。
 
-派工决策前优先使用：
-
-- Glob / LS / 目录树
-- 主 Agent 的只读 Bash：`ls`、`find`、`wc -l`、`git status` 等
-- 必要的外部 WebSearch / WebFetch，用于补最新 API / spec / 错误码
-
-避免仅为了决定“要不要派”而先 Read/Grep 大量源码。如果主 Agent 已经拥有相关上下文，则直接利用已有上下文，不必机械遵守该启发式。
+派工决策前优先使用 Glob / LS / 目录树、只读 Bash（如 `ls`、`find`、`wc -l`、`git status`）和必要的外部 WebSearch / WebFetch。避免仅为了决定“要不要派”而先 Read/Grep 大量源码；若主 Agent 已经拥有相关上下文，直接利用即可。
 
 ## 6. 派工粒度
 
-优先派**完整逻辑单元**，不要把一个 feature 拆成大量微任务。
+优先派**完整逻辑单元**，不要把一个 feature 拆成大量微任务。合适的单元应尽量满足：目标清晰、输入/输出边界明确、可独立验证、所需 context 能一次性给齐。
 
-合适的单元应尽量满足：
-
-- 目标清晰
-- 输入/输出边界明确
-- 可独立验证
-- 所需 context 能一次性给齐
-
-主 Agent负责识别单元、定义接口和最终整合；DeepSeek 负责单元内部的 Read / Implement / Test 循环。
-
-如果一个子任务必须频繁回来询问主 Agent 或依赖前一个子任务的临时结果，通常应合并，而不是继续拆细。
+主 Agent 负责识别单元、定义接口和最终整合；DeepSeek 负责单元内部的 Read / Implement / Test 循环。如果子任务必须频繁回来询问主 Agent 或依赖前一个子任务的临时结果，通常应合并。
 
 ## 7. task / context 怎么写
 
 DeepSeek 看不到主对话历史、主 Agent 私有记忆或未显式提供的项目约定。调用时给足完成任务所需的信息，但不要放 API key、凭证或不应发送到外部 API 的敏感数据。
 
-`task` 至少包含：
+`task` 至少写清：目标、范围/路径（已知时）、边界、可验证成功标准。
 
-- 要做什么
-- 涉及路径/范围（已知时）
-- 明确边界
-- 可验证的成功标准
+`context` 只补必要信息：技术栈/版本、命名/schema/接口约定、已知项目规则、外部文档关键结论、已知坑或失败现象。
 
-`context` 只补充真正必要的信息，例如：
-
-- 项目技术栈 / 版本
-- 命名、schema、接口约定
-- 主 Agent 已知的项目规则摘要
-- 外部文档/API 的关键结论
-- 已知坑或失败现象
-
-普通任务省略 `model`：
+普通任务省略 `model`；困难任务明确升级：
 
 ```text
 mcp__deepseek__delegate_to_deepseek(
   task="<目标 + 范围 + 成功标准>",
-  context="<必要约定 / 外部资料摘要>"
-)
-```
-
-困难任务显式升级：
-
-```text
-mcp__deepseek__delegate_to_deepseek(
-  task="<困难任务 + 成功标准>",
   context="<必要上下文>",
-  model="pro"
+  model="pro"  # 普通任务删除此行，默认 Flash
 )
 ```
 
 ## 8. 外部知识 pre-flight
 
-DeepSeek 没有 web 工具。任务依赖最新或不熟悉的外部知识时，主 Agent 先查官方/可靠资料，把**摘要**放进 `context`，再派工。
-
-常见触发：
-
-- 新版本框架 / API
-- 小众依赖
-- 协议 / spec
-- SaaS API
-- 明确错误码 / breaking change
-
-不需要为 Python stdlib、基础 SQL、常见 shell 等常识做额外 pre-flight。
+DeepSeek 没有 web 工具。任务依赖最新或不熟悉的框架/API、小众依赖、协议/spec、SaaS API、错误码或 breaking change 时，主 Agent 先查官方/可靠资料，把**摘要**放进 `context` 再派工。常识性内容无需额外搜索。
 
 ## 9. 派工后验收
 
-DeepSeek 自报完成不等于完成。主 Agent 至少做与风险匹配的独立验证：
+DeepSeek 自报完成不等于完成。主 Agent 至少：
 
-1. 查看关键 diff / 产物文件。
-2. 检查 schema、接口、边界和数量级是否符合要求。
+1. 查看关键 diff / 产物。
+2. 检查 schema、接口、边界和数量级。
 3. 能运行测试/静态检查时运行。
-4. mutation 任务按 recovery 协议核验和 acknowledge。
+4. mutation 任务按 recovery 协议核验并 acknowledge。
 
-问题处理：
+小问题主 Agent 直接修；明显遗漏但仍适合委派时给明确反馈重试；Flash 能力不足可新建 Pro 任务；大范围错误、权限问题或连续失败则停止派工并接管。
 
-- 小问题：主 Agent 直接修。
-- 明显遗漏但任务仍适合委派：补充明确反馈后重试；Flash 能力不足时可升级 Pro。
-- 大范围错误、权限问题或连续失败：停止派工，由主 Agent 接管。
-
-## 10. Fallback
+## 10. Fallback 与用户控制
 
 | 情况 | 处理 |
 |---|---|
 | MCP / API 未配置或不可用 | 主 Agent 接管 |
-| capability/tool not allowed | 不绕过权限；主 Agent 接管或让 operator 调整配置 |
+| capability/tool not allowed | 不绕过权限；接管或让 operator 调整配置 |
 | busy / workspace already owned | 处理现有 job 后再派，不并发写同一 workspace |
 | 超 max_turns / 任务过大 | 按独立逻辑单元拆分 |
 | Flash 质量不足 | 验证后新建 Pro 任务 |
 | 连续两次质量差 | 本会话停止主动派工 |
-
-## 11. 用户显式控制
-
-| 用户说 | 行为 |
-|---|---|
-| “派给 DS / DeepSeek” | 强制派，默认 Flash；明显困难可 Pro |
-| `/ds <task>` | 同上 |
-| “你自己干 / 别派” | 不派 |
+| 用户说“派给 DS / DeepSeek”或 `/ds` | 强制派，默认 Flash；明显困难可 Pro |
+| 用户说“你自己干 / 别派” | 不派 |
 | `DEEPSEEK_MODE=off` / pure 模式 | 不派 |

--- a/skills/delegate-to-deepseek/SKILL.md
+++ b/skills/delegate-to-deepseek/SKILL.md
@@ -31,17 +31,17 @@ description: 默认把中等及以下、批量、重复或机械任务作为完�
 
 - `ping()`：检查 MCP 服务是否可用。
 
-- `delegate_to_deepseek(task, context="")`：同步执行完整 coding 任务；调用后只能等待结果，中途不能 steering、查询状态或取消。`task` 是目标与验收标准；可选 `context` 补充路径、约束和项目约定。
+- `delegate_to_deepseek(task, context="", model="flash")`：同步执行完整 coding 任务；调用后只能等待结果，中途不能 steering、查询状态或取消。`task` 是目标与验收标准；可选 `context` 补充路径、约束和项目约定。
 
-- `delegate_to_deepseek_readonly(task, context="")`：同步执行只读分析，仅限 Read / Glob / Grep；参数同上，调用后同样只能等待结果。
+- `delegate_to_deepseek_readonly(task, context="", model="flash")`：同步执行只读分析，仅限 Read / Glob / Grep；参数同上，调用后同样只能等待结果。
 
-- `start_deepseek(task, context="")`：启动后台 coding 任务，返回 `job_id`。
+- `start_deepseek(task, context="", model="flash")`：启动后台 coding 任务，返回 `job_id`。
 
-- `start_deepseek_readonly(task, context="")`：启动后台只读任务，返回 `job_id`。
+- `start_deepseek_readonly(task, context="", model="flash")`：启动后台只读任务，返回 `job_id`。
 
 - `get_deepseek_status(job_id)`：查看后台任务状态。`job_id` 是对应 `start_*` 返回的标识。
 
-- `send_deepseek_message(job_id, message)`：向后台任务追加或修正指令。`message` 不能改变该 job 已冻结的能力。
+- `send_deepseek_message(job_id, message)`：向后台任务追加或修正指令。`message` 不能改变该 job 已冻结的能力或模型。
 
 - `cancel_deepseek(job_id)`：取消后台任务。
 
@@ -51,19 +51,39 @@ description: 默认把中等及以下、批量、重复或机械任务作为完�
 
 - `acknowledge_deepseek_mutations(transaction_ids)`：核验后确认修改记录；`transaction_ids` 必须是 recovery 返回的精确 ID 列表。
 
-**选择规则**：能直接等待完成时用 `delegate_*`；需要 steering、状态查询或取消时用 `start_*`。纯阅读、搜索、review 已存在文件或文本，且整个任务不执行任何命令时用 readonly；其余或不确定时用 coding。readonly job 后续需要 Bash 或修改文件时，不能 steering 提权；应取消或结束该 job，再新建 coding job。
+### 模型路由
+
+`model` 只允许 `flash` 或 `pro`。不传时固定使用 `flash`。
+
+- `flash`：默认通用子代理，能力定位约为 **Sonnet / Terra 档**（roughly Sonnet/Terra-tier）。用于正常 coding、review、调查、重构、测试、批处理和常规多文件任务。
+- `pro`：困难任务子代理，能力定位约为 **Opus / Sol 档**（roughly Opus/Sol-tier）。用于复杂 debugging、架构级推理、困难多文件推理，或 Flash 已明显不足/失败后的升级。
+- 不要因为 Pro 可用就默认选择 Pro；没有明确困难信号时保持 Flash。
+- 后台 job 在 `start_*` 时冻结模型；`send_deepseek_message` 不得把运行中的 Flash job 切成 Pro，反之亦然。需要换模型时结束或取消当前 job，再新建 job。
+
+**重要：`flash/pro` 是稳定路由槽位，不是 provider 的真实模型名。** 主 Agent 永远只传 `model="flash"` 或 `model="pro"`，不得把 `deepseek-v4-*`、未来 V4.1/V5 名称或第三方兼容端点的模型名直接塞进 MCP 参数。实际 provider 模型名由用户在 `~/.deepseek-mcp/config.json` 中配置，例如：
+
+```json
+{
+  "flash": "deepseek-v4-flash",
+  "pro": "deepseek-v4-pro"
+}
+```
+
+用户可在模型升级后自行修改这两个值，而不改变主 Agent 的调用方式。旧版单 `model` 字段仅作为升级兼容；新配置应使用 `flash` / `pro`。
+
+**选择规则**：能直接等待完成时用 `delegate_*`；需要 steering、状态查询或取消时用 `start_*`。纯阅读、搜索、review 已存在文件或文本，且整个任务不执行任何命令时用 readonly；其余或不确定时用 coding。readonly job 后续需要 Bash 或修改文件时，不能 steering 提权；应取消或结束该 job，再新建 coding job。模型选择与 coding/readonly 能力选择相互独立。
 
 ## 🚀 核心理念：能派就派
 
-DeepSeek v4-pro 已经很强，在当前配置下通常比主 Agent 模型便宜。主 Agent 的稀缺资源是高成本模型配额，DeepSeek 的稀缺资源主要是调用费用。**默认派**，以下场景默认由主 Agent 自己处理：
+默认 Flash 已经是强通用子代理，并且通常比主 Agent 模型便宜；真正困难的任务再显式升级到 Pro。主 Agent 的稀缺资源是高成本模型配额，DeepSeek 的稀缺资源主要是调用费用。**默认派**，以下场景默认由主 Agent 自己处理：
 
 - ❌ 任务依赖 CLAUDE.md / 项目内部约定文档（DS 拿不到主 Agent 端的记忆）
-- ❌ 跨领域架构设计 / 技术选型 / ADR（需要主 Agent 的综合推理）
-- ❌ 跨领域或结论不明确的 bug 根因分析（推理密集，默认由主 Agent 负责）
+- ❌ 跨领域架构设计 / 技术选型 / ADR（需要主 Agent 的综合推理；主 Agent 若决定委派此类困难任务，应使用 `model="pro"`）
+- ❌ 跨领域或结论不明确的 bug 根因分析（推理密集，默认由主 Agent 负责；若决定委派深入调查，应使用 `model="pro"`）
 - ❌ 单文件 < 200 行的微调（DS 的 reasoning 起步成本 > 省下的主 Agent tokens）
 - ❌ 用户明确说"你自己干 / 别派"
 
-**其他任务默认派**。包括但不限于："写个 X"、"补测试"、"修这个 lint"、"重命名 Y 到 Z"、"扫日志"、"翻译这段"、"实现这个 endpoint"。
+**其他任务默认派**。包括但不限于："写个 X"、"补测试"、"修这个 lint"、"重命名 Y 到 Z"、"扫日志"、"翻译这段"、"实现这个 endpoint"。默认不传 `model`，即使用 Flash。
 
 ## 默认时机：尽量在主 Agent 读源码之前决定是否派工
 
@@ -111,10 +131,10 @@ DeepSeek v4-pro 已经很强，在当前配置下通常比主 Agent 模型便宜
 
 | 难度 | 例子 | 默认 |
 |---|---|---|
-| 🟢 **简单** | 写 hello world / 单脚本、写测试用例、补文档、单 endpoint CRUD、单组件实现 | ✅ **派** |
-| 🟡 **中等** | 3-10 文件 batch 改、一个 feature 的实现（spec 清晰）、补全测试、生成 boilerplate、简单 refactor、扫日志 / ETL | ✅ **派** |
-| 🟠 **中等偏上** | 10+ 文件批量、一个领域内的 refactor、性能优化（数据已给）、i18n 提取、协议转换 | ✅ **派**（必要时拆批） |
-| 🔴 **困难** | 跨领域架构设计、技术选型、ADR、bug 根因分析、需要项目深度约定 | ❌ **自己干** |
+| 🟢 **简单** | 写 hello world / 单脚本、写测试用例、补文档、单 endpoint CRUD、单组件实现 | ✅ **派 Flash** |
+| 🟡 **中等** | 3-10 文件 batch 改、一个 feature 的实现（spec 清晰）、补全测试、生成 boilerplate、简单 refactor、扫日志 / ETL | ✅ **派 Flash** |
+| 🟠 **中等偏上** | 10+ 文件批量、一个领域内的 refactor、性能优化（数据已给）、i18n 提取、协议转换 | ✅ **派 Flash**（必要时拆批；明显推理密集可升 Pro） |
+| 🔴 **困难** | 跨领域架构设计、技术选型、ADR、bug 根因分析、需要项目深度约定 | ❌ **默认自己干**；若高把握决定派则 **Pro** |
 | 🌶️ **极小** | 单文件 < 200 行的 typo / rename / 加注释 | ❌ **自己干**（DS overhead 不划算） |
 
 **简单 / 中等 / 中等偏上默认都派**。不要因为"听起来简单我顺手就做了"而省略派工 —— 那省的是 5 分钟，烧的是几万主 Agent tokens。（主 Agent 高把握时可自行处理。）
@@ -123,13 +143,13 @@ DeepSeek v4-pro 已经很强，在当前配置下通常比主 Agent 模型便宜
 
 | 用户说 / 看到 | 主 Agent 行为 |
 |---|---|
-| "写一个 X" / "实现 Y" / "做一个 Z" | 派（除非命中🔴/🌶️） |
-| "重命名 / 批量改 / 翻译 / 提取" | 派 |
-| "测试 / 文档 / boilerplate / lint 修" | 派 |
-| "为啥这个 bug" / "为啥这里挂了" | 静态代码/日志调查可派给 readonly；跨领域或结论不明确时自己干 |
+| "写一个 X" / "实现 Y" / "做一个 Z" | 派 Flash（除非命中🔴/🌶️） |
+| "重命名 / 批量改 / 翻译 / 提取" | 派 Flash |
+| "测试 / 文档 / boilerplate / lint 修" | 派 Flash |
+| "为啥这个 bug" / "为啥这里挂了" | 静态代码/日志调查可派 readonly Flash；明显困难且决定派深入调查时 Pro；跨领域或结论不明确时默认自己干 |
 | "我应该用 A 还是 B" | 自己干（选型） |
 | "改个 typo / rename 一个变量" | 自己干（极小，DS overhead 不值） |
-| "派给 DS" / `/ds <任务>` | 强制派 |
+| "派给 DS" / `/ds <任务>` | 强制派；默认 Flash，任务明显困难时可 Pro |
 | "你自己干" / "别派" | 强制不派 |
 
 ---
@@ -147,7 +167,7 @@ DeepSeek v4-pro 已经很强，在当前配置下通常比主 Agent 模型便宜
 | **拆任务税** | 主 Agent 想"怎么拆 / 给什么 context / 怎么 task" 本身烧主 Agent tokens |
 | **上下文重读税** | 主 Agent 一个对话里读过的文件下次还能引用；DS 每次 delegate 是独立进程，**同样的文件要重新读 N 遍** |
 | **验证税** | DS 每完成一次主 Agent 要 Read 抽样验证；拆越多次 → 验证越多 |
-| **DS 起步费** | v4-pro thinking mode 每次启动 ~5-10k reasoning tokens 起步；拆 10 次 = 50-100k 起步费 |
+| **DS 起步费** | thinking mode 每次委派都有 reasoning 起步开销；拆成多个微任务会重复支付起步成本 |
 | **碎片返工税** | 子任务之间缺全局视野，产物不一致；返工时拆+重做+重验全来一遍 |
 
 ### 数学直觉（按主 Agent 等价成本）
@@ -205,8 +225,8 @@ DeepSeek v4-pro 已经很强，在当前配置下通常比主 Agent 模型便宜
 
 ### 唯一应该警惕的"不该派"信号
 
-- DS 的 reasoning tokens 起步开销大（v4-pro thinking mode）：**单纯写一个 hello world 也烧 ~8k tokens**
-- 所以"几乎无 Read、改动 < 200 行" → 主 Agent 自己 5 行就搞定，比 DS 8k tokens 划算
+- DS 的 thinking/reasoning 每次委派都有起步开销，极小任务可能不划算
+- 所以"几乎无 Read、改动 < 200 行" → 主 Agent 自己几行就能搞定时，通常比启动 DS 更划算
 
 ---
 
@@ -289,6 +309,8 @@ context="项目 fastapi 0.115，参考 API 用法：
 
 ## 派工模板
 
+普通任务省略 `model`，默认 Flash：
+
 ```
 mcp__deepseek__delegate_to_deepseek(
   task="<清晰描述要做什么 + 成功标准 + 涉及路径>
@@ -296,6 +318,16 @@ mcp__deepseek__delegate_to_deepseek(
 
   context="<项目约定 / 框架版本 / schema / 边界 / 已知坑>
   - 完成后请抽样 verify N 个产物"
+)
+```
+
+困难任务需要明确升级时：
+
+```
+mcp__deepseek__delegate_to_deepseek(
+  task="<困难任务 + 成功标准>",
+  context="<必要上下文>",
+  model="pro"
 )
 ```
 
@@ -350,6 +382,7 @@ DeepSeek 自报"完成"不等于真的完成。**主 Agent 必须验证**：
 | capability/tool not allowed | 当前安全配置未授权；不要绕过，主 Agent 接管或让 operator 审核配置 |
 | busy / workspace already owned | 同一工作区已有执行；取回/取消当前 job 后再决定，不要并发写 |
 | Agent loop 超 max_turns | 任务太大；拆小再派（"先做前 25 个文件"） |
+| Flash 质量不足 | 先独立验证；任务仍适合委派时可新建 `model="pro"` 的任务重试 |
 | 产物质量差 | 验证后修；累计 2 次差 → 后续主动跳过 delegate（本会话） |
 | 用户连续 2 次 `pure` 启动 | 默认不派工，等用户显式 `/ds` 才派 |
 
@@ -364,7 +397,7 @@ DeepSeek 自报"完成"不等于真的完成。**主 Agent 必须验证**：
 
 | 用户说 | 主 Agent 行为 |
 |---|---|
-| "派给 DS" / "外包给 deepseek" | 强制调用本工具，不再自行判断 |
+| "派给 DS" / "外包给 deepseek" | 强制调用本工具，不再自行判断；默认 Flash，明显困难任务可 Pro |
 | "你自己干" / "别派" | 禁止调本工具，本对话主动 fallback |
 | `/ds <task>` (slash command) | 等同"派给 DS" |
 | 启动用 `pure` 命令 | DEEPSEEK_MODE=off，本工具立即返回 disabled |

--- a/skills/delegate-to-deepseek/SKILL.md
+++ b/skills/delegate-to-deepseek/SKILL.md
@@ -1,329 +1,140 @@
 ---
 name: delegate-to-deepseek
-description: 默认把中等及以下、批量、重复或机械任务作为完整逻辑单元派给 DeepSeek，并由主 Agent 独立验收。适用于批量改文件、扫日志、翻译、ETL、脚本、测试、文档、CRUD、单领域重构、单组件或单 endpoint。派工时机、读源码限制、任务粒度和自行处理清单均为默认启发式；主 Agent 若基于当前上下文判断把握大，可突破这些默认限制。用户显式指令、安全、权限、隐私边界和派工后验证不可突破。DEEPSEEK_MODE=off 时跳过。
+description: 默认把中等及以下、批量、重复或机械任务作为完整逻辑单元派给 DeepSeek，并由主 Agent 独立验收。适用于批量改文件、扫日志、翻译、ETL、脚本、测试、文档、CRUD、单领域重构、单组件或单 endpoint。主 Agent 可基于上下文和失败代价调整派工策略；用户显式指令、安全、权限、隐私边界和派工后验证不可突破。DEEPSEEK_MODE=off 时跳过。
 ---
 
-# delegate-to-deepseek — 主 Agent 派工给 DeepSeek 的准则
+# delegate-to-deepseek — 主 Agent 派工准则
 
-> “主 Agent”指负责决策、整合与验收的上层 agent。
+“主 Agent”指负责决策、整合与最终验收的上层 agent。
 
-## 🧭 最高优先级：主 Agent 高把握裁量权
+## 1. 不可突破的边界
 
-除下方“不可突破项”外，本文的“默认派 / 自己干 / 派工前禁读 / 完整逻辑单元”等都是成本优化启发式，不是绝对限制。主 Agent 基于已掌握的上下文、改动范围、失败代价和验证手段判断把握大时，可以直接突破，包括：
+- 用户显式要求派 / 不派、指定执行者或执行方式时，优先服从用户。
+- 权限、安全、隐私、敏感信息和非授权写入边界不可绕过。
+- `DEEPSEEK_MODE=off` 时不要派工。
+- DeepSeek 读取的文件内容会发送到配置的 API endpoint；敏感工作区不得派工。
+- coding 能力固定为 Read / Write / Edit / Bash / Glob / Grep / NotebookEdit；readonly 固定为 Read / Glob / Grep。不得通过 task、steering 或其它参数提权。
+- coding Bash 是受边界约束的 trusted-host Bash，不是操作系统级沙箱。
+- 派工结果必须由主 Agent独立验证，失败由主 Agent 收口。
+- 出现文件 mutation、取消、断连或 MCP 重启后，先调用 `get_deepseek_recovery()`，核验实际文件，再用精确 transaction IDs 调用 `acknowledge_deepseek_mutations(...)`；未确认前不要重试 mutation delegation。
 
-- 自己完成本来默认应派的任务，或把默认自己做的任务派出
-- 读源码后仍派工，或先派后由主 Agent 接管
-- 按实际依赖调整粒度，不受固定文件数、行数或任务类型约束
+## 2. API 选择
 
-启用裁量时，用一句话说明具体依据即可；“顺手做”或“感觉可以”不算依据。
-
-**不可突破项**：
-
-- 用户显式要求派 / 不派、指定执行者或执行方式
-- 权限、安全、隐私、敏感信息和非授权写入边界
-- 派工结果必须由主 Agent 独立验证，失败时由主 Agent 负责收口
-- 环境变量 `DEEPSEEK_MODE=off` 时本 skill 立即 disabled
-- API 能力由服务端固定：coding 为 Read/Write/Edit/Bash/Glob/Grep/NotebookEdit；只读为 Read/Glob/Grep。不得尝试通过 task、steering 或工具参数改变它
-- DeepSeek 读取的文件内容会随模型消息发送到配置的 API endpoint；敏感工作区不得派工
-- 每次出现文件 mutation、取消、断连或 MCP 重启后，必须调用 `get_deepseek_recovery`，逐项核验实际文件，再把精确 transaction ID 交给 `acknowledge_deepseek_mutations`；未确认前不得重试委派
-
-## API 与选择规则
-
-- `ping()`：检查 MCP 服务是否可用。
-
-- `delegate_to_deepseek(task, context="", model="flash")`：同步执行完整 coding 任务；调用后只能等待结果，中途不能 steering、查询状态或取消。`task` 是目标与验收标准；可选 `context` 补充路径、约束和项目约定。
-
-- `delegate_to_deepseek_readonly(task, context="", model="flash")`：同步执行只读分析，仅限 Read / Glob / Grep；参数同上，调用后同样只能等待结果。
-
-- `start_deepseek(task, context="", model="flash")`：启动后台 coding 任务，返回 `job_id`。
-
-- `start_deepseek_readonly(task, context="", model="flash")`：启动后台只读任务，返回 `job_id`。
-
-- `get_deepseek_status(job_id)`：查看后台任务状态。`job_id` 是对应 `start_*` 返回的标识。
-
-- `send_deepseek_message(job_id, message)`：向后台任务追加或修正指令。`message` 不能改变该 job 已冻结的能力或模型。
-
-- `cancel_deepseek(job_id)`：取消后台任务。
-
-- `get_deepseek_result(job_id)`：获取后台任务最终结果；尚未完成时返回未就绪状态。
-
-- `get_deepseek_recovery()`：查看 coding 任务产生、待主 Agent 核验的文件修改记录。
-
-- `acknowledge_deepseek_mutations(transaction_ids)`：核验后确认修改记录；`transaction_ids` 必须是 recovery 返回的精确 ID 列表。
-
-### 模型路由
-
-`model` 只允许 `flash` 或 `pro`。不传时固定使用 `flash`。
-
-- `flash`：默认通用子代理，能力定位约为 **Sonnet / Terra 档**（roughly Sonnet/Terra-tier）。用于正常 coding、review、调查、重构、测试、批处理和常规多文件任务。
-- `pro`：困难任务子代理，能力定位约为 **Opus / Sol 档**（roughly Opus/Sol-tier）。用于复杂 debugging、架构级推理、困难多文件推理，或 Flash 已明显不足/失败后的升级。
-- 不要因为 Pro 可用就默认选择 Pro；没有明确困难信号时保持 Flash。
-- 后台 job 在 `start_*` 时冻结模型；`send_deepseek_message` 不得把运行中的 Flash job 切成 Pro，反之亦然。需要换模型时结束或取消当前 job，再新建 job。
-
-**重要：`flash/pro` 是稳定路由槽位，不是 provider 的真实模型名。** 主 Agent 永远只传 `model="flash"` 或 `model="pro"`，不得把 `deepseek-v4-*`、未来 V4.1/V5 名称或第三方兼容端点的模型名直接塞进 MCP 参数。实际 provider 模型名由用户在 `~/.deepseek-mcp/config.json` 中配置，例如：
-
-```json
-{
-  "flash": "deepseek-v4-flash",
-  "pro": "deepseek-v4-pro"
-}
-```
-
-用户可在模型升级后自行修改这两个值，而不改变主 Agent 的调用方式。旧版单 `model` 字段仅作为升级兼容；新配置应使用 `flash` / `pro`。
-
-**选择规则**：能直接等待完成时用 `delegate_*`；需要 steering、状态查询或取消时用 `start_*`。纯阅读、搜索、review 已存在文件或文本，且整个任务不执行任何命令时用 readonly；其余或不确定时用 coding。readonly job 后续需要 Bash 或修改文件时，不能 steering 提权；应取消或结束该 job，再新建 coding job。模型选择与 coding/readonly 能力选择相互独立。
-
-## 🚀 核心理念：能派就派
-
-默认 Flash 已经是强通用子代理，并且通常比主 Agent 模型便宜；真正困难的任务再显式升级到 Pro。主 Agent 的稀缺资源是高成本模型配额，DeepSeek 的稀缺资源主要是调用费用。**默认派**，以下场景默认由主 Agent 自己处理：
-
-- ❌ 任务依赖 CLAUDE.md / 项目内部约定文档（DS 拿不到主 Agent 端的记忆）
-- ❌ 跨领域架构设计 / 技术选型 / ADR（需要主 Agent 的综合推理；主 Agent 若决定委派此类困难任务，应使用 `model="pro"`）
-- ❌ 跨领域或结论不明确的 bug 根因分析（推理密集，默认由主 Agent 负责；若决定委派深入调查，应使用 `model="pro"`）
-- ❌ 单文件 < 200 行的微调（DS 的 reasoning 起步成本 > 省下的主 Agent tokens）
-- ❌ 用户明确说"你自己干 / 别派"
-
-**其他任务默认派**。包括但不限于："写个 X"、"补测试"、"修这个 lint"、"重命名 Y 到 Z"、"扫日志"、"翻译这段"、"实现这个 endpoint"。默认不传 `model`，即使用 Flash。
-
-## 默认时机：尽量在主 Agent 读源码之前决定是否派工
-
-派工是为了**省主 Agent 的 token**。如果主 Agent 已经 Read 过源码，源码就进了主对话上下文，token 已经烧了。再派给 DeepSeek，DS 还要**再读一遍**（拿不到主 Agent 内存里的内容），变成**双倍消耗**：
-
-```
-错误时机（双倍消耗）             正确时机（净省）
-─────────────────                ──────────────
-用户提出任务                     用户提出任务
-    │                                │
-    ▼                                ▼
-主 Agent Read 50 个文件 ─ 烧 100k      主 Agent Glob 看范围 ─ 烧 500
-    │                                │
-    ▼                                ▼
-"嗯，看完了，这事得派 DS"          "范围清楚了" → 立刻派
-    │                                │
-    ▼                                ▼
-派给 DS（DS 再 Read 100k）         DS 一次性接管所有 Read + 处理
-    │                                │
-  ❌ 总成本 = 主 Agent 100k +           ✅ 总成本 = 主 Agent 500 +
-            DS 100k + verify 20k             DS 100k + verify 20k
-                                              （省 100k 主 Agent token）
-```
-
-### 派工决策前默认可用的工具
-
-✅ `Glob` —— 看有多少文件、什么扩展名
-✅ `LS` —— 看目录结构
-✅ 主 Agent 自己的 `Bash` 只读命令 —— `ls`、`wc -l`、`find . -name`、`du -sh`、`git status`
-✅ `WebSearch` / `WebFetch` —— 查外部文档 / 新 API / 错误码（用来给 DS 补 context，Anthropic 包了费用）
-
-### 派工决策前默认避免的工具
-
-❌ `Read` —— 一旦读就污染上下文，sunk cost 让派工不再合算
-❌ `Grep` —— 同上，会把匹配行带进上下文
-
-只读 DeepSeek API 没有 Bash。coding API 的 Bash 在可信宿主机上以
-`cwd=workspace` 运行，不是操作系统级沙箱；它仍受时限、输出上限和凭证隔离约束。
-
-**判断口诀**：**判断不了"该不该派"？默认派 —— DS 多烧几千 token 是小事，主 Agent 多烧 100k 才是大事。**
-
----
-
-## 难度分级 + 派工决策
-
-| 难度 | 例子 | 默认 |
-|---|---|---|
-| 🟢 **简单** | 写 hello world / 单脚本、写测试用例、补文档、单 endpoint CRUD、单组件实现 | ✅ **派 Flash** |
-| 🟡 **中等** | 3-10 文件 batch 改、一个 feature 的实现（spec 清晰）、补全测试、生成 boilerplate、简单 refactor、扫日志 / ETL | ✅ **派 Flash** |
-| 🟠 **中等偏上** | 10+ 文件批量、一个领域内的 refactor、性能优化（数据已给）、i18n 提取、协议转换 | ✅ **派 Flash**（必要时拆批；明显推理密集可升 Pro） |
-| 🔴 **困难** | 跨领域架构设计、技术选型、ADR、bug 根因分析、需要项目深度约定 | ❌ **默认自己干**；若高把握决定派则 **Pro** |
-| 🌶️ **极小** | 单文件 < 200 行的 typo / rename / 加注释 | ❌ **自己干**（DS overhead 不划算） |
-
-**简单 / 中等 / 中等偏上默认都派**。不要因为"听起来简单我顺手就做了"而省略派工 —— 那省的是 5 分钟，烧的是几万主 Agent tokens。（主 Agent 高把握时可自行处理。）
-
-### 决策快速通道
-
-| 用户说 / 看到 | 主 Agent 行为 |
+| 需求 | API |
 |---|---|
-| "写一个 X" / "实现 Y" / "做一个 Z" | 派 Flash（除非命中🔴/🌶️） |
-| "重命名 / 批量改 / 翻译 / 提取" | 派 Flash |
-| "测试 / 文档 / boilerplate / lint 修" | 派 Flash |
-| "为啥这个 bug" / "为啥这里挂了" | 静态代码/日志调查可派 readonly Flash；明显困难且决定派深入调查时 Pro；跨领域或结论不明确时默认自己干 |
-| "我应该用 A 还是 B" | 自己干（选型） |
-| "改个 typo / rename 一个变量" | 自己干（极小，DS overhead 不值） |
-| "派给 DS" / `/ds <任务>` | 强制派；默认 Flash，任务明显困难时可 Pro |
-| "你自己干" / "别派" | 强制不派 |
+| coding，直接等结果 | `delegate_to_deepseek(task, context="", model="flash")` |
+| 纯静态文件分析，直接等结果 | `delegate_to_deepseek_readonly(task, context="", model="flash")` |
+| coding，需要 steering / status / cancel | `start_deepseek(task, context="", model="flash")` |
+| readonly，需要 steering / status / cancel | `start_deepseek_readonly(task, context="", model="flash")` |
+| 查询后台任务 | `get_deepseek_status(job_id)` |
+| 追加/修正后台指令 | `send_deepseek_message(job_id, message)` |
+| 取消后台任务 | `cancel_deepseek(job_id)` |
+| 获取最终结果 | `get_deepseek_result(job_id)` |
+| 查询 mutation recovery | `get_deepseek_recovery()` |
+| 确认已核验 mutation | `acknowledge_deepseek_mutations(transaction_ids)` |
 
----
+只读、搜索、review 已存在文件且整个任务不执行命令/写文件时用 readonly；其余或不确定时用 coding。readonly job 后续需要 Bash 或写文件时，结束/取消后重新启动 coding job，不能 steering 提权。
 
-## 🧩 派工粒度（默认）：完整逻辑单元 > 细颗粒步骤
+## 3. 模型路由
 
-> 💡 此粒度准则为默认启发式。主 Agent 可基于对任务的理解调整粒度（合并/拆分），见顶部裁量权规则。
+`model` 只允许 `flash` 或 `pro`；不传时使用 `flash`。
 
-**核心反直觉**：拆得越细 ≠ 越省钱。拆过头反而比不派还贵。
+- **Flash**：默认通用子代理，约 **Sonnet / Terra 档**。用于正常 coding、review、调查、重构、测试、批处理和常规多文件任务。
+- **Pro**：困难任务子代理，约 **Opus / Sol 档**。用于复杂 debugging、架构级推理、困难多文件推理，或 Flash 已明显不足后的升级。
+- 没有明确困难信号时保持 Flash；不要因为 Pro 可用就默认 Pro。
+- 主 Agent 只选择 `flash/pro`，不要尝试控制 reasoning effort；thinking 档位由用户配置决定。
+- background job 启动时冻结模型与能力。需要换模型时结束/取消当前 job，再新建 job。
 
-### 5 个"反派工税"（拆越细，越亏）
+## 4. 默认派工策略
 
-| 税种 | 机制 |
+**默认派给 Flash：**
+
+- 脚本、测试、文档、CRUD、单组件 / 单 endpoint
+- 批量修改、重命名、翻译、提取、ETL、日志扫描
+- spec 清晰的 feature
+- 单领域重构、常规多文件任务
+- 静态代码/日志调查（优先 readonly）
+
+**默认由主 Agent 自己处理：**
+
+- 用户明确要求自己处理
+- 极小改动：几乎无需读上下文即可完成的 typo / 单变量 rename / 少量注释
+- 跨领域架构设计、技术选型、ADR
+- 结论高度不明确、需要大量主 Agent 综合上下文的根因分析
+- 强依赖主 Agent 私有记忆、CLAUDE.md 或未提供给 DeepSeek 的项目约定
+
+这些是成本优化启发式，不是绝对限制。主 Agent 对任务边界、失败代价和验证手段有高把握时，可以调整；但不可突破第 1 节的边界。
+
+### 快速判断
+
+| 信号 | 默认行为 |
 |---|---|
-| **拆任务税** | 主 Agent 想"怎么拆 / 给什么 context / 怎么 task" 本身烧主 Agent tokens |
-| **上下文重读税** | 主 Agent 一个对话里读过的文件下次还能引用；DS 每次 delegate 是独立进程，**同样的文件要重新读 N 遍** |
-| **验证税** | DS 每完成一次主 Agent 要 Read 抽样验证；拆越多次 → 验证越多 |
-| **DS 起步费** | thinking mode 每次委派都有 reasoning 起步开销；拆成多个微任务会重复支付起步成本 |
-| **碎片返工税** | 子任务之间缺全局视野，产物不一致；返工时拆+重做+重验全来一遍 |
+| “写 / 实现 / 补测试 / 批量改 / 翻译 / 提取” | Flash |
+| 普通 review / 静态调查 | readonly Flash |
+| 明显复杂 debug / 架构级推理 | Pro（若决定委派） |
+| Flash 已验证不足 | 新建 Pro 任务 |
+| 极小改动 | 主 Agent 自己做 |
+| “派给 DS” / `/ds` | 强制派，默认 Flash；明显困难可 Pro |
+| “你自己干 / 别派” | 不派 |
 
-### 数学直觉（按主 Agent 等价成本）
+## 5. 派工时机
 
-| 策略 | 总成本 |
-|---|---|
-| 主 Agent 自己干完 | 1.0X |
-| 派 1 个完整逻辑单元给 DS | ~0.13X ✅ **省 87%** |
-| 派 5 个子任务（拆步骤） | ~0.50X 省 50% |
-| 派 10 个微任务 | ~0.95X ❌ 几乎不省 |
-| 派 20 个细任务 | ~1.88X ❌ **比不派还贵** |
+尽量在主 Agent 大量读取项目源码之前决定是否派工，避免主 Agent 和 DeepSeek 重复加载同一批上下文。
 
-### 真省钱的形态
+派工决策前优先使用：
 
-✅ **派"完整逻辑单元"**，DS 内部 loop 自己跑 10-30 turns 一次到位：
-- "实现这个 feature 端到端" → 1 次 delegate，DS 自己 Read/Write/Test 循环
-- "把这 50 个文件批量改一遍" → 1 次 delegate，DS 内部跑文件循环
-- "扫整个 logs/ 目录提取错误栈" → 1 次 delegate，DS 跑遍所有日志文件
+- Glob / LS / 目录树
+- 主 Agent 的只读 Bash：`ls`、`find`、`wc -l`、`git status` 等
+- 必要的外部 WebSearch / WebFetch，用于补最新 API / spec / 错误码
 
-❌ **不要**拆"做 feature 的第 1 步、第 2 步、第 3 步"分别派：
-- 每步都要主 Agent 拆 + 验证 + DS 重读上下文，5 个税全中
-- 不如让 DS 一次性接管整个 feature
+避免仅为了决定“要不要派”而先 Read/Grep 大量源码。如果主 Agent 已经拥有相关上下文，则直接利用已有上下文，不必机械遵守该启发式。
 
-### 拆分原则（主 Agent 干这部分）
+## 6. 派工粒度
 
-主 Agent 的活是**"识别逻辑单元 + 设计接口 + 整合"**，DS 的活是**"单元的完整实现"**：
+优先派**完整逻辑单元**，不要把一个 feature 拆成大量微任务。
 
-1. **识别**：什么是"完整逻辑单元"？接口清晰、可独立验证、自包含（不依赖另一个 DS 任务的产物）
-2. **设计**：单元之间的输入输出格式（schema / 文件路径），主 Agent 定，DS 实现
-3. **整合**：DS 干完后主 Agent 串起来，必要时做最后的胶水代码 / 验证
+合适的单元应尽量满足：
 
-### 一个测试：要不要再拆？
+- 目标清晰
+- 输入/输出边界明确
+- 可独立验证
+- 所需 context 能一次性给齐
 
-派工前问自己：**"这个子任务能给一个 1 周新人，一次性给完所有 context，让他独立完成吗？"**
-- 能 → 派给 DS 没问题
-- 不能（需要中途回来问问题 / 看前序结果）→ **不要拆出来**，让它和前序合并成一个更大的单元
+主 Agent负责识别单元、定义接口和最终整合；DeepSeek 负责单元内部的 Read / Implement / Test 循环。
 
-## 💰 token 经济学（让主 Agent 心里有账）
+如果一个子任务必须频繁回来询问主 Agent 或依赖前一个子任务的临时结果，通常应合并，而不是继续拆细。
 
-### 派工真省钱的公式
+## 7. task / context 怎么写
 
-```
-派工净省 = (主 Agent 不派会烧的 tokens)
-        - (主 Agent 准备 task + 验证产物 烧的 tokens)
-        - (DeepSeek 烧的 tokens × 价格折算系数 ≈ 0.1x)
-```
+DeepSeek 看不到主对话历史、主 Agent 私有记忆或未显式提供的项目约定。调用时给足完成任务所需的信息，但不要放 API key、凭证或不应发送到外部 API 的敏感数据。
 
-折算系数 0.1x 意味着 **DS 烧 10k tokens 才相当于主 Agent 1k tokens 的钱**。所以即使 task 不大，派工也常常划算。
+`task` 至少包含：
 
-### 反直觉但常见的"该派"信号
+- 要做什么
+- 涉及路径/范围（已知时）
+- 明确边界
+- 可验证的成功标准
 
-- "这事我 5 分钟自己写完" → **如果要 Read 文件 / 写 50+ 行**，那 5 分钟也烧 10-20k 主 Agent tokens，派给 DS 更便宜
-- "DeepSeek 估计要折腾几轮" → 让它折腾，反正它便宜
-- "代码量小不至于派吧" → 看是不是 < 200 行**且无依赖读取**。要 Read 几个文件才能开始写？派
+`context` 只补充真正必要的信息，例如：
 
-### 唯一应该警惕的"不该派"信号
+- 项目技术栈 / 版本
+- 命名、schema、接口约定
+- 主 Agent 已知的项目规则摘要
+- 外部文档/API 的关键结论
+- 已知坑或失败现象
 
-- DS 的 thinking/reasoning 每次委派都有起步开销，极小任务可能不划算
-- 所以"几乎无 Read、改动 < 200 行" → 主 Agent 自己几行就能搞定时，通常比启动 DS 更划算
+普通任务省略 `model`：
 
----
-
-## 派工前默认准备（避免上下文丢失）
-
-DeepSeek 进入 sub-agent 后**看不到**主对话历史、CLAUDE.md、项目内部约定文档或主 Agent 内存。所有它需要的上下文（包括外部资料）都应通过 `task` 和 `context` 参数传过去；不要把 API key 或其它凭证放进去。
-
-调用前主 Agent **默认只用 Glob / LS / 自己的只读 Bash**（尽量不 Read）收集：
-
-```
-1. 用 Glob 列出涉及的文件路径（如果有），传给 DeepSeek
-2. 摘要项目约定（从主 Agent 自己已有的记忆，不要去 Read CLAUDE.md）：
-   - 命名规则、输出 schema、边界
-   - 技术栈（语言版本、框架、关键依赖）
-3. 明确成功标准：
-   - 应该生成 / 修改什么
-   - 完成的 verifiable 信号（"写一个 fastapi endpoint，curl localhost/x 返回 200"）
-```
-
-## 🌐 用主 Agent 自己的 WebSearch / WebFetch 给 DS 补外部知识
-
-**关键认识**：DeepSeek sub-agent 没有 web 工具。主 Agent 可使用当前环境提供的 `WebSearch` / `WebFetch` 或等价外部资料工具。
-
-**派工前规则**：如果任务需要主 Agent 自己不熟的外部知识，**主 Agent 应该用 WebSearch / WebFetch 或等价工具查好，把结果摘要塞进 `context`**。这条规则不冲突（外部资料工具拿到的不是项目代码，不计入项目代码的 sunk cost）。
-
-### 何时该 pre-flight 搜索
-
-| 任务里出现的信号 | 主 Agent 该搜什么 |
-|---|---|
-| 用新版本 / 新框架 API（"FastAPI 0.115"、"Tailwind v4"） | 最新文档 / changelog / breaking changes |
-| 用主 Agent 不确定的库（小众 / niche） | 库的 README + 主要 API 示例 |
-| 实现某协议 / spec（"OIDC"、"WebRTC SDP"） | spec 关键章节摘要 |
-| 修一个有错误码的 bug | 错误码对应的官方说明 / 已知 issue |
-| 用某 SaaS API（DeepSeek API、Stripe API） | 官方 endpoint + 参数 schema 摘要 |
-| 性能优化某算法 | 已知最佳实现 / benchmark 数据 |
-
-### Pre-flight 搜索模板
-
-```
-1. 用 WebSearch 查 1-3 个 query（不要狂搜，省 Anthropic 配额）
-2. 摘要关键信息：
-   - API 签名 / 参数表
-   - 必要的 import / setup
-   - 常见坑 / breaking change
-3. 把摘要塞进 delegate_to_deepseek(context=...) 的开头
-4. 派工
-```
-
-### 实例：DS 实现一个 fastapi SSE endpoint
-
-**❌ 不 pre-flight 的派工（DS 拿不到最新文档，写出来可能用 0.95 时代的旧 API）**：
-```
-task="实现一个 fastapi SSE endpoint /events 推流。"
-context="项目用 fastapi 0.115。"
-```
-
-**✅ pre-flight 后的派工**：
-```
-（先由主 Agent 调用 WebSearch 或等价工具："fastapi SSE EventSourceResponse 0.115 example"）
-（拿到关键代码片段，摘要进 context）
-
-task="实现 fastapi SSE endpoint /events 推流。"
-context="项目 fastapi 0.115，参考 API 用法：
-- from sse_starlette.sse import EventSourceResponse
-- 返回 EventSourceResponse(generator())
-- generator 是 async def，yield dict {'event': 'msg', 'data': '...'}
-- 客户端用 EventSource API 接收
-
-边界：放在 api/events.py，复用 db session = Depends(get_session)
-成功标准：curl -N localhost:8000/events 拿到 SSE 流。"
-```
-
-第二种 DS 一次就写对的概率显著提高。
-
-### 何时不需要 pre-flight
-
-- DS 应该会的常识（Python stdlib、shell 命令、SQL 基础）
-- 项目内部 idiom（用 Glob/LS 收集而非 web 搜索）
-- 任务本身就是搜索（"扫这些日志找 X"）—— 没什么需要外部资料的
-
-## 派工模板
-
-普通任务省略 `model`，默认 Flash：
-
-```
+```text
 mcp__deepseek__delegate_to_deepseek(
-  task="<清晰描述要做什么 + 成功标准 + 涉及路径>
-        （相对路径以配置的 workspace 为基准；默认跟随主 Agent 启动目录）",
-
-  context="<项目约定 / 框架版本 / schema / 边界 / 已知坑>
-  - 完成后请抽样 verify N 个产物"
+  task="<目标 + 范围 + 成功标准>",
+  context="<必要约定 / 外部资料摘要>"
 )
 ```
 
-困难任务需要明确升级时：
+困难任务显式升级：
 
-```
+```text
 mcp__deepseek__delegate_to_deepseek(
   task="<困难任务 + 成功标准>",
   context="<必要上下文>",
@@ -331,73 +142,51 @@ mcp__deepseek__delegate_to_deepseek(
 )
 ```
 
-### 实例
+## 8. 外部知识 pre-flight
 
-**🟢 简单（写脚本）**：
-```
-task="在 scripts/ 下写一个 batch_rename.py，把当前目录所有 *.JPG 改成 *.jpg。
-      用 pathlib，不要 os.system。运行成功后打印改名数量。"
-context="项目 Python 版本以 pyproject.toml 为准，没有第三方依赖。"
-```
+DeepSeek 没有 web 工具。任务依赖最新或不熟悉的外部知识时，主 Agent 先查官方/可靠资料，把**摘要**放进 `context`，再派工。
 
-**🟡 中等（实现 endpoint）**：
-```
-task="在 api/users.py 里加一个 GET /users/:id endpoint，返回 user 详情 JSON。
-      表已经在 db/schema.sql 里（users 表）。用 FastAPI + SQLAlchemy async。
-      成功标准：curl localhost:8000/users/1 返回 {id, name, email}。"
-context="项目用 FastAPI 0.115，DB session 注入用 Depends(get_session)。
-        路由模块约定：每个文件一个 router 实例，名字叫 router。
-        完成后补路由测试；主 Agent 负责起服务与网络验收。"
-```
+常见触发：
 
-**🟠 中等偏上（批量提取）**：
-```
-task="把 Resources/*.lproj/Localizable.strings 里的所有 key 提取到
-      keys.json，schema: { 'file': str, 'keys': [str] }。
-      逐文件处理，写到 ./keys.json。"
-context="key 命名是 lowerCamelCase；.strings 格式: \"key\" = \"value\";
-        注释行（// 开头）忽略。完成后抽样 verify 3 个文件。"
-```
+- 新版本框架 / API
+- 小众依赖
+- 协议 / spec
+- SaaS API
+- 明确错误码 / breaking change
 
-## 派工后必须做的（避免盲信）
+不需要为 Python stdlib、基础 SQL、常见 shell 等常识做额外 pre-flight。
 
-DeepSeek 自报"完成"不等于真的完成。**主 Agent 必须验证**：
+## 9. 派工后验收
 
-```
-1. 用 Read 抽样读 1-2 个产物文件（不必读全部）—— 这次允许 Read，因为是新产物
-2. 检查 schema 是否符合要求
-3. 数量 sanity check（"50 个文件应该生成 ≥50 条 key"）
-4. 如果发现质量问题：
-   a. 轻微（几条漏了）→ 主 Agent 自己补
-   b. 严重（schema 错 / 大面积缺失）→ Edit 修后再 delegate 一次
-   c. 灾难（DeepSeek 完全没干完）→ 自己接管 + 告知用户外包失败
-```
+DeepSeek 自报完成不等于完成。主 Agent 至少做与风险匹配的独立验证：
 
-## Fallback 策略
+1. 查看关键 diff / 产物文件。
+2. 检查 schema、接口、边界和数量级是否符合要求。
+3. 能运行测试/静态检查时运行。
+4. mutation 任务按 recovery 协议核验和 acknowledge。
 
-| 症状 | 处理 |
+问题处理：
+
+- 小问题：主 Agent 直接修。
+- 明显遗漏但任务仍适合委派：补充明确反馈后重试；Flash 能力不足时可升级 Pro。
+- 大范围错误、权限问题或连续失败：停止派工，由主 Agent 接管。
+
+## 10. Fallback
+
+| 情况 | 处理 |
 |---|---|
-| `ERROR: deepseek-mcp not configured` | 告诉用户："DeepSeek 没配 key，我自己干" + 主 Agent 接管 |
-| `ERROR: DeepSeek API error` | MCP 已自动重试 2 次；仍失败 → 自己接管 |
-| capability/tool not allowed | 当前安全配置未授权；不要绕过，主 Agent 接管或让 operator 审核配置 |
-| busy / workspace already owned | 同一工作区已有执行；取回/取消当前 job 后再决定，不要并发写 |
-| Agent loop 超 max_turns | 任务太大；拆小再派（"先做前 25 个文件"） |
-| Flash 质量不足 | 先独立验证；任务仍适合委派时可新建 `model="pro"` 的任务重试 |
-| 产物质量差 | 验证后修；累计 2 次差 → 后续主动跳过 delegate（本会话） |
-| 用户连续 2 次 `pure` 启动 | 默认不派工，等用户显式 `/ds` 才派 |
+| MCP / API 未配置或不可用 | 主 Agent 接管 |
+| capability/tool not allowed | 不绕过权限；主 Agent 接管或让 operator 调整配置 |
+| busy / workspace already owned | 处理现有 job 后再派，不并发写同一 workspace |
+| 超 max_turns / 任务过大 | 按独立逻辑单元拆分 |
+| Flash 质量不足 | 验证后新建 Pro 任务 |
+| 连续两次质量差 | 本会话停止主动派工 |
 
-## 通用工程纪律（派工不豁免）
+## 11. 用户显式控制
 
-- 派工前充分收集 context，不留半成品给 DS
-- 不要把 API key / 敏感数据塞进 task / context，也不要让 DeepSeek 读取未获准发送到 API 的文件
-- 不要 sleep 等 DeepSeek 完成 —— 工具调用同步返回
-- DS 的产物仍要按 SOLID / 项目代码规范抽查，派工不豁免代码质量责任
-
-## 用户显式控制
-
-| 用户说 | 主 Agent 行为 |
+| 用户说 | 行为 |
 |---|---|
-| "派给 DS" / "外包给 deepseek" | 强制调用本工具，不再自行判断；默认 Flash，明显困难任务可 Pro |
-| "你自己干" / "别派" | 禁止调本工具，本对话主动 fallback |
-| `/ds <task>` (slash command) | 等同"派给 DS" |
-| 启动用 `pure` 命令 | DEEPSEEK_MODE=off，本工具立即返回 disabled |
+| “派给 DS / DeepSeek” | 强制派，默认 Flash；明显困难可 Pro |
+| `/ds <task>` | 同上 |
+| “你自己干 / 别派” | 不派 |
+| `DEEPSEEK_MODE=off` / pure 模式 | 不派 |

--- a/src/deepseek_mcp/config.py
+++ b/src/deepseek_mcp/config.py
@@ -18,6 +18,7 @@ MAX_CONFIG_BYTES = 1024 * 1024
 DEFAULT_FLASH_MODEL = "deepseek-v4-flash"
 DEFAULT_PRO_MODEL = "deepseek-v4-pro"
 DEFAULT_REASONING_EFFORT = "high"
+PROVIDER_DEFAULT_REASONING_EFFORT = "provider-default"
 REASONING_EFFORT_OPTIONS = ("none", "low", "high", "max")
 # Kept as the active-model default for internal/backward-compatible Config construction.
 DEFAULT_MODEL = DEFAULT_FLASH_MODEL
@@ -55,6 +56,7 @@ CONFIG_KEYS = frozenset(
     }
 )
 logger = logging.getLogger(__name__)
+
 def _validate_private_directory(path: Path) -> None:
     if os.name != "posix":
         return
@@ -71,6 +73,7 @@ def _validate_private_directory(path: Path) -> None:
             f"Config directory must be owned by the current user with mode 0700: {path}"
         )
 
+
 def _validate_private_file(descriptor: int) -> None:
     metadata = os.fstat(descriptor)
     if not stat.S_ISREG(metadata.st_mode):
@@ -82,6 +85,7 @@ def _validate_private_file(descriptor: int) -> None:
             f"Config must be owned by the current user and private; "
             f"run: chmod 700 {CONFIG_PATH.parent} && chmod 600 {CONFIG_PATH}"
         )
+
 
 def _read_config_text() -> str:
     if os.name == "nt":
@@ -184,6 +188,7 @@ def _load_api_key(data: dict) -> str:
         logger.warning("DeepSeek API key does not start with 'sk-'; verify the key")
     return credential
 
+
 def _workspace_setting(data: dict) -> tuple[object | None, bool]:
     environment = os.getenv("DEEPSEEK_WORKSPACE")
     if environment is not None:
@@ -285,16 +290,22 @@ def _validate_reasoning_effort(value: object, field_name: str) -> str:
     return value
 
 
+def _validate_runtime_reasoning_effort(value: object, field_name: str) -> str:
+    if value == PROVIDER_DEFAULT_REASONING_EFFORT:
+        return PROVIDER_DEFAULT_REASONING_EFFORT
+    return _validate_reasoning_effort(value, field_name)
+
+
+def _load_reasoning_effort(data: dict, field_name: str) -> str:
+    if field_name not in data:
+        return PROVIDER_DEFAULT_REASONING_EFFORT
+    return _validate_reasoning_effort(data[field_name], field_name)
+
+
 def _load_reasoning_efforts(data: dict) -> tuple[str, str]:
     return (
-        _validate_reasoning_effort(
-            data.get("flash_reasoning_effort", DEFAULT_REASONING_EFFORT),
-            "flash_reasoning_effort",
-        ),
-        _validate_reasoning_effort(
-            data.get("pro_reasoning_effort", DEFAULT_REASONING_EFFORT),
-            "pro_reasoning_effort",
-        ),
+        _load_reasoning_effort(data, "flash_reasoning_effort"),
+        _load_reasoning_effort(data, "pro_reasoning_effort"),
     )
 
 
@@ -362,13 +373,13 @@ class Config:
         self.model = _validate_model(self.model)
         self.flash_model = _validate_model(self.flash_model, "flash")
         self.pro_model = _validate_model(self.pro_model, "pro")
-        self.reasoning_effort = _validate_reasoning_effort(
+        self.reasoning_effort = _validate_runtime_reasoning_effort(
             self.reasoning_effort, "reasoning_effort"
         )
-        self.flash_reasoning_effort = _validate_reasoning_effort(
+        self.flash_reasoning_effort = _validate_runtime_reasoning_effort(
             self.flash_reasoning_effort, "flash_reasoning_effort"
         )
-        self.pro_reasoning_effort = _validate_reasoning_effort(
+        self.pro_reasoning_effort = _validate_runtime_reasoning_effort(
             self.pro_reasoning_effort, "pro_reasoning_effort"
         )
         self.base_url = _validate_base_url(self.base_url)

--- a/src/deepseek_mcp/config.py
+++ b/src/deepseek_mcp/config.py
@@ -15,7 +15,10 @@ from .safety import is_unsafe_workspace_root
 from .workspace_guard import configure_workspace_identity
 CONFIG_PATH = Path.home() / ".deepseek-mcp" / "config.json"
 MAX_CONFIG_BYTES = 1024 * 1024
-DEFAULT_MODEL = "deepseek-v4-flash"
+DEFAULT_FLASH_MODEL = "deepseek-v4-flash"
+DEFAULT_PRO_MODEL = "deepseek-v4-pro"
+# Kept as the active-model default for internal/backward-compatible Config construction.
+DEFAULT_MODEL = DEFAULT_FLASH_MODEL
 DEFAULT_MAX_TURNS = 50
 MAX_TURNS = 100
 DEFAULT_MAX_RUN_SECONDS = 5 * 60 * 60
@@ -37,7 +40,9 @@ CONFIG_KEYS = frozenset(
     {
         "api_key",
         "workspace",
-        "model",
+        "model",  # legacy single-model config; accepted for upgrade compatibility
+        "flash",
+        "pro",
         "max_turns",
         "max_run_seconds",
         "allowed_tools",
@@ -244,12 +249,28 @@ def _load_allowed_tools(data: dict) -> list[str]:
     return list(tools)
 
 
-def _validate_model(value: object) -> str:
+def _validate_model(value: object, field_name: str = "model") -> str:
     if not isinstance(value, str) or not value.strip():
-        raise RuntimeError("model must be a non-empty string")
+        raise RuntimeError(f"{field_name} must be a non-empty string")
     if value != value.strip() or any(ord(char) < 32 for char in value):
-        raise RuntimeError("model must not contain surrounding or control whitespace")
+        raise RuntimeError(
+            f"{field_name} must not contain surrounding or control whitespace"
+        )
     return value
+
+
+def _load_model_slots(data: dict) -> tuple[str, str]:
+    """Load user-configurable provider model IDs for the public Flash/Pro slots."""
+    if "model" in data:
+        if "flash" in data or "pro" in data:
+            raise RuntimeError("legacy model cannot be combined with flash/pro")
+        legacy = _validate_model(data["model"], "model")
+        # Preserve old single-model configs exactly across the routing upgrade.
+        return legacy, legacy
+    return (
+        _validate_model(data.get("flash", DEFAULT_FLASH_MODEL), "flash"),
+        _validate_model(data.get("pro", DEFAULT_PRO_MODEL), "pro"),
+    )
 
 
 def _parse_base_url(value: object):
@@ -291,6 +312,7 @@ def _validate_base_url(value: object) -> str:
 class Config:
     api_key: str
     workspace: Path
+    # Active provider model for this execution. Public hosts never set this directly.
     model: str = DEFAULT_MODEL
     max_turns: int = DEFAULT_MAX_TURNS
     allowed_tools: list[str] = field(default_factory=lambda: list(DEFAULT_ALLOWED_TOOLS))
@@ -298,6 +320,9 @@ class Config:
     max_run_seconds: int = DEFAULT_MAX_RUN_SECONDS
     delegation_capability: str = field(default="coding", repr=False)
     expected_workspace_identity: str | None = field(default=None, repr=False)
+    # User-configurable provider model IDs behind the stable public Flash/Pro slots.
+    flash_model: str = DEFAULT_FLASH_MODEL
+    pro_model: str = DEFAULT_PRO_MODEL
 
     def __post_init__(self) -> None:
         if is_unsafe_workspace_root(self.workspace):
@@ -306,6 +331,8 @@ class Config:
             self.workspace, self.expected_workspace_identity
         )
         self.model = _validate_model(self.model)
+        self.flash_model = _validate_model(self.flash_model, "flash")
+        self.pro_model = _validate_model(self.pro_model, "pro")
         self.base_url = _validate_base_url(self.base_url)
         self.max_turns = _validate_max_turns(self.max_turns)
         self.max_run_seconds = _validate_max_run_seconds(self.max_run_seconds)
@@ -328,16 +355,19 @@ class Config:
 
     @classmethod
     def _from_data(cls, data: dict, credential: str) -> "Config":
+        flash_model, pro_model = _load_model_slots(data)
         return cls(
             credential,
             workspace=_load_workspace(data),
-            model=data.get("model", DEFAULT_MODEL),
+            model=flash_model,
             max_turns=_load_max_turns(data),
             max_run_seconds=_validate_max_run_seconds(
                 data.get("max_run_seconds", DEFAULT_MAX_RUN_SECONDS)
             ),
             allowed_tools=_load_allowed_tools(data),
             base_url=data.get("base_url", "https://api.deepseek.com"),
+            flash_model=flash_model,
+            pro_model=pro_model,
         )
 
     @classmethod

--- a/src/deepseek_mcp/config.py
+++ b/src/deepseek_mcp/config.py
@@ -17,6 +17,8 @@ CONFIG_PATH = Path.home() / ".deepseek-mcp" / "config.json"
 MAX_CONFIG_BYTES = 1024 * 1024
 DEFAULT_FLASH_MODEL = "deepseek-v4-flash"
 DEFAULT_PRO_MODEL = "deepseek-v4-pro"
+DEFAULT_REASONING_EFFORT = "high"
+REASONING_EFFORT_OPTIONS = ("none", "low", "high", "max")
 # Kept as the active-model default for internal/backward-compatible Config construction.
 DEFAULT_MODEL = DEFAULT_FLASH_MODEL
 DEFAULT_MAX_TURNS = 50
@@ -43,6 +45,9 @@ CONFIG_KEYS = frozenset(
         "model",  # legacy single-model config; accepted for upgrade compatibility
         "flash",
         "pro",
+        "flash_reasoning_effort",
+        "pro_reasoning_effort",
+        "_reasoning_effort_options",  # installer hint only; ignored by runtime
         "max_turns",
         "max_run_seconds",
         "allowed_tools",
@@ -273,6 +278,26 @@ def _load_model_slots(data: dict) -> tuple[str, str]:
     )
 
 
+def _validate_reasoning_effort(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or value not in REASONING_EFFORT_OPTIONS:
+        allowed = ", ".join(REASONING_EFFORT_OPTIONS)
+        raise RuntimeError(f"{field_name} must be one of: {allowed}")
+    return value
+
+
+def _load_reasoning_efforts(data: dict) -> tuple[str, str]:
+    return (
+        _validate_reasoning_effort(
+            data.get("flash_reasoning_effort", DEFAULT_REASONING_EFFORT),
+            "flash_reasoning_effort",
+        ),
+        _validate_reasoning_effort(
+            data.get("pro_reasoning_effort", DEFAULT_REASONING_EFFORT),
+            "pro_reasoning_effort",
+        ),
+    )
+
+
 def _parse_base_url(value: object):
     if not isinstance(value, str) or not value:
         raise RuntimeError("base_url must be a non-empty string")
@@ -323,6 +348,10 @@ class Config:
     # User-configurable provider model IDs behind the stable public Flash/Pro slots.
     flash_model: str = DEFAULT_FLASH_MODEL
     pro_model: str = DEFAULT_PRO_MODEL
+    # Active effort plus the user-configured effort attached to each public slot.
+    reasoning_effort: str = DEFAULT_REASONING_EFFORT
+    flash_reasoning_effort: str = DEFAULT_REASONING_EFFORT
+    pro_reasoning_effort: str = DEFAULT_REASONING_EFFORT
 
     def __post_init__(self) -> None:
         if is_unsafe_workspace_root(self.workspace):
@@ -333,6 +362,15 @@ class Config:
         self.model = _validate_model(self.model)
         self.flash_model = _validate_model(self.flash_model, "flash")
         self.pro_model = _validate_model(self.pro_model, "pro")
+        self.reasoning_effort = _validate_reasoning_effort(
+            self.reasoning_effort, "reasoning_effort"
+        )
+        self.flash_reasoning_effort = _validate_reasoning_effort(
+            self.flash_reasoning_effort, "flash_reasoning_effort"
+        )
+        self.pro_reasoning_effort = _validate_reasoning_effort(
+            self.pro_reasoning_effort, "pro_reasoning_effort"
+        )
         self.base_url = _validate_base_url(self.base_url)
         self.max_turns = _validate_max_turns(self.max_turns)
         self.max_run_seconds = _validate_max_run_seconds(self.max_run_seconds)
@@ -356,6 +394,7 @@ class Config:
     @classmethod
     def _from_data(cls, data: dict, credential: str) -> "Config":
         flash_model, pro_model = _load_model_slots(data)
+        flash_effort, pro_effort = _load_reasoning_efforts(data)
         return cls(
             credential,
             workspace=_load_workspace(data),
@@ -368,6 +407,9 @@ class Config:
             base_url=data.get("base_url", "https://api.deepseek.com"),
             flash_model=flash_model,
             pro_model=pro_model,
+            reasoning_effort=flash_effort,
+            flash_reasoning_effort=flash_effort,
+            pro_reasoning_effort=pro_effort,
         )
 
     @classmethod

--- a/src/deepseek_mcp/model_selection.py
+++ b/src/deepseek_mcp/model_selection.py
@@ -5,15 +5,11 @@ from typing import Literal
 
 ModelChoice = Literal["flash", "pro"]
 
-_MODEL_IDS = {
-    "flash": "deepseek-v4-flash",
-    "pro": "deepseek-v4-pro",
-}
 
-
-def resolve_model(choice: str) -> str:
-    """Resolve the stable public profile to the provider model id."""
-    try:
-        return _MODEL_IDS[choice]
-    except KeyError:
-        raise ValueError("model must be exactly 'flash' or 'pro'") from None
+def resolve_model(choice: str, *, flash_model: str, pro_model: str) -> str:
+    """Resolve a stable public profile to the user-configured provider model ID."""
+    if choice == "flash":
+        return flash_model
+    if choice == "pro":
+        return pro_model
+    raise ValueError("model must be exactly 'flash' or 'pro'")

--- a/src/deepseek_mcp/model_selection.py
+++ b/src/deepseek_mcp/model_selection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Literal
 
 ModelChoice = Literal["flash", "pro"]
+ReasoningEffort = Literal["none", "low", "high", "max"]
 
 
 def resolve_model(choice: str, *, flash_model: str, pro_model: str) -> str:
@@ -12,4 +13,15 @@ def resolve_model(choice: str, *, flash_model: str, pro_model: str) -> str:
         return flash_model
     if choice == "pro":
         return pro_model
+    raise ValueError("model must be exactly 'flash' or 'pro'")
+
+
+def resolve_reasoning_effort(
+    choice: str, *, flash_effort: str, pro_effort: str
+) -> str:
+    """Resolve the reasoning effort configured for a public model profile."""
+    if choice == "flash":
+        return flash_effort
+    if choice == "pro":
+        return pro_effort
     raise ValueError("model must be exactly 'flash' or 'pro'")

--- a/src/deepseek_mcp/model_selection.py
+++ b/src/deepseek_mcp/model_selection.py
@@ -25,3 +25,20 @@ def resolve_reasoning_effort(
     if choice == "pro":
         return pro_effort
     raise ValueError("model must be exactly 'flash' or 'pro'")
+
+
+def resolve_profile(
+    choice: str,
+    *,
+    flash_model: str,
+    pro_model: str,
+    flash_effort: str,
+    pro_effort: str,
+) -> tuple[str, str]:
+    """Resolve provider model ID and reasoning effort for one public profile."""
+    return (
+        resolve_model(choice, flash_model=flash_model, pro_model=pro_model),
+        resolve_reasoning_effort(
+            choice, flash_effort=flash_effort, pro_effort=pro_effort
+        ),
+    )

--- a/src/deepseek_mcp/provider_child.py
+++ b/src/deepseek_mcp/provider_child.py
@@ -90,7 +90,8 @@ def _request_arguments(
         "messages": messages,
         "max_tokens": MAX_OUTPUT_TOKENS_PER_REQUEST,
     }
-    _apply_reasoning_settings(arguments, settings.get("reasoning_effort", "high"))
+    if "reasoning_effort" in settings:
+        _apply_reasoning_settings(arguments, settings["reasoning_effort"])
     if tools:
         arguments["tools"] = tools
     return arguments
@@ -232,8 +233,7 @@ def main() -> None:
     except BaseException:
         try:
             _write_payload(
-                {"kind": "error", "summary": "category=client", "retryable": False
-                }
+                {"kind": "error", "summary": "category=client", "retryable": False}
             )
         except BaseException:
             pass

--- a/src/deepseek_mcp/provider_child.py
+++ b/src/deepseek_mcp/provider_child.py
@@ -25,6 +25,7 @@ MAX_OUTPUT_TOKENS_PER_REQUEST = 16_384
 MAX_REQUEST_BYTES = 16 * 1024 * 1024
 MAX_RESPONSE_BYTES = 4 * 1024 * 1024
 MAX_API_RESPONSE_BYTES = 2 * 1024 * 1024
+_REASONING_EFFORTS = frozenset({"none", "low", "high", "max"})
 
 for _name in ("openai", "httpx", "httpcore"):
     _logger = logging.getLogger(_name)
@@ -71,6 +72,16 @@ def _trust_proxy_environment(base_url: str) -> bool:
     )
 
 
+def _apply_reasoning_settings(arguments: dict[str, Any], effort: object) -> None:
+    if not isinstance(effort, str) or effort not in _REASONING_EFFORTS:
+        raise ValueError("invalid reasoning effort")
+    if effort == "none":
+        arguments["extra_body"] = {"thinking": {"type": "disabled"}}
+        return
+    arguments["reasoning_effort"] = effort
+    arguments["extra_body"] = {"thinking": {"type": "enabled"}}
+
+
 def _request_arguments(
     settings: dict[str, str], messages: list[dict], tools: list[dict]
 ) -> dict[str, Any]:
@@ -79,6 +90,7 @@ def _request_arguments(
         "messages": messages,
         "max_tokens": MAX_OUTPUT_TOKENS_PER_REQUEST,
     }
+    _apply_reasoning_settings(arguments, settings.get("reasoning_effort", "high"))
     if tools:
         arguments["tools"] = tools
     return arguments
@@ -220,7 +232,8 @@ def main() -> None:
     except BaseException:
         try:
             _write_payload(
-                {"kind": "error", "summary": "category=client", "retryable": False}
+                {"kind": "error", "summary": "category=client", "retryable": False
+                }
             )
         except BaseException:
             pass

--- a/src/deepseek_mcp/provider_process.py
+++ b/src/deepseek_mcp/provider_process.py
@@ -101,6 +101,7 @@ def _encoded_request(config, messages: list[dict], tools: list[dict]) -> bytes:
             "credential": getattr(config, "api_" + "key"),
             "base_url": config.base_url,
             "model": config.model,
+            "reasoning_effort": config.reasoning_effort,
         },
         "messages": messages,
         "tools": tools,

--- a/src/deepseek_mcp/provider_process.py
+++ b/src/deepseek_mcp/provider_process.py
@@ -101,7 +101,7 @@ def _encoded_request(config, messages: list[dict], tools: list[dict]) -> bytes:
             "credential": getattr(config, "api_" + "key"),
             "base_url": config.base_url,
             "model": config.model,
-            "reasoning_effort": config.reasoning_effort,
+            "reasoning_effort": getattr(config, "reasoning_effort", "high"),
         },
         "messages": messages,
         "tools": tools,

--- a/src/deepseek_mcp/provider_process.py
+++ b/src/deepseek_mcp/provider_process.py
@@ -96,13 +96,16 @@ def _request_end(deadline: Deadline | None) -> tuple[Deadline, bool]:
 
 
 def _encoded_request(config, messages: list[dict], tools: list[dict]) -> bytes:
+    settings = {
+        "credential": getattr(config, "api_" + "key"),
+        "base_url": config.base_url,
+        "model": config.model,
+    }
+    reasoning_effort = getattr(config, "reasoning_effort", None)
+    if reasoning_effort not in (None, "provider-default"):
+        settings["reasoning_effort"] = reasoning_effort
     payload = {
-        "settings": {
-            "credential": getattr(config, "api_" + "key"),
-            "base_url": config.base_url,
-            "model": config.model,
-            "reasoning_effort": getattr(config, "reasoning_effort", "high"),
-        },
+        "settings": settings,
         "messages": messages,
         "tools": tools,
     }

--- a/src/deepseek_mcp/server.py
+++ b/src/deepseek_mcp/server.py
@@ -37,7 +37,7 @@ from .execution_profile import (
 )
 from .host_instructions import HOST_INSTRUCTIONS as _HOST_INSTRUCTIONS
 from .job_manager import DeepSeekJobManager, JobBusy, JobError, validate_delegation_input
-from .model_selection import ModelChoice, resolve_model
+from .model_selection import ModelChoice, resolve_profile
 from .private_logging import PrivateBoundedLogStream
 from .process_hardening import disable_core_dumps
 from .transaction_recovery import (
@@ -46,7 +46,6 @@ from .transaction_recovery import (
 )
 
 _VALID_MODES = frozenset({"auto", "off"})
-
 def _deepseek_mode() -> str:
     value = os.getenv("DEEPSEEK_MODE", "auto")
     if value not in _VALID_MODES:
@@ -185,8 +184,8 @@ def ping() -> str:
         ws_short = _shorten_path(cfg.workspace)
         tools = ",".join(cfg.allowed_tools)
         config_status = (
-            f"workspace={ws_short} (sandbox), flash={cfg.flash_model}, "
-            f"pro={cfg.pro_model}, tools={tools}"
+            f"workspace={ws_short} (sandbox), flash={cfg.flash_model}/{cfg.flash_reasoning_effort}, "
+            f"pro={cfg.pro_model}/{cfg.pro_reasoning_effort}, tools={tools}"
         )
     except Exception as e:
         config_status = f"NOT_CONFIGURED ({e})"
@@ -235,10 +234,10 @@ def _load_config(profile: ExecutionProfile = CODING_PROFILE, model: ModelChoice 
         raise JobError("DeepSeek delegation is disabled (DEEPSEEK_MODE=off)")
     try:
         config = configure_delegation(Config.load(), profile)
-        config.model = resolve_model(
-            model,
-            flash_model=config.flash_model,
-            pro_model=config.pro_model,
+        config.model, config.reasoning_effort = resolve_profile(
+            model, flash_model=config.flash_model, pro_model=config.pro_model,
+            flash_effort=config.flash_reasoning_effort,
+            pro_effort=config.pro_reasoning_effort,
         )
         return config
     except JobError:

--- a/src/deepseek_mcp/server.py
+++ b/src/deepseek_mcp/server.py
@@ -185,7 +185,8 @@ def ping() -> str:
         ws_short = _shorten_path(cfg.workspace)
         tools = ",".join(cfg.allowed_tools)
         config_status = (
-            f"workspace={ws_short} (sandbox), model={cfg.model}, tools={tools}"
+            f"workspace={ws_short} (sandbox), flash={cfg.flash_model}, "
+            f"pro={cfg.pro_model}, tools={tools}"
         )
     except Exception as e:
         config_status = f"NOT_CONFIGURED ({e})"
@@ -234,7 +235,11 @@ def _load_config(profile: ExecutionProfile = CODING_PROFILE, model: ModelChoice 
         raise JobError("DeepSeek delegation is disabled (DEEPSEEK_MODE=off)")
     try:
         config = configure_delegation(Config.load(), profile)
-        config.model = resolve_model(model)
+        config.model = resolve_model(
+            model,
+            flash_model=config.flash_model,
+            pro_model=config.pro_model,
+        )
         return config
     except JobError:
         raise

--- a/tests/test_config_model_slots.py
+++ b/tests/test_config_model_slots.py
@@ -9,6 +9,8 @@ from deepseek_mcp.config import (
     Config,
     DEFAULT_FLASH_MODEL,
     DEFAULT_PRO_MODEL,
+    DEFAULT_REASONING_EFFORT,
+    REASONING_EFFORT_OPTIONS,
 )
 
 
@@ -28,14 +30,45 @@ class ConfigModelSlotTests(unittest.TestCase):
         self.assertEqual(config.flash_model, DEFAULT_FLASH_MODEL)
         self.assertEqual(config.pro_model, DEFAULT_PRO_MODEL)
         self.assertEqual(config.model, DEFAULT_FLASH_MODEL)
+        self.assertEqual(config.flash_reasoning_effort, DEFAULT_REASONING_EFFORT)
+        self.assertEqual(config.pro_reasoning_effort, DEFAULT_REASONING_EFFORT)
+        self.assertEqual(config.reasoning_effort, DEFAULT_REASONING_EFFORT)
+        self.assertEqual(REASONING_EFFORT_OPTIONS, ("none", "low", "high", "max"))
 
-    def test_flash_and_pro_accept_user_provider_model_names(self) -> None:
+    def test_flash_and_pro_accept_user_provider_model_names_and_efforts(self) -> None:
         config = self._load_from_data(
-            {"flash": "deepseek-v4.1-flash", "pro": "deepseek-v4.1-pro"}
+            {
+                "flash": "deepseek-v4.1-flash",
+                "flash_reasoning_effort": "none",
+                "pro": "deepseek-v4.1-pro",
+                "pro_reasoning_effort": "max",
+                "_reasoning_effort_options": ["none", "low", "high", "max"],
+            }
         )
         self.assertEqual(config.flash_model, "deepseek-v4.1-flash")
         self.assertEqual(config.pro_model, "deepseek-v4.1-pro")
         self.assertEqual(config.model, "deepseek-v4.1-flash")
+        self.assertEqual(config.flash_reasoning_effort, "none")
+        self.assertEqual(config.pro_reasoning_effort, "max")
+        self.assertEqual(config.reasoning_effort, "none")
+
+    def test_reasoning_effort_hint_field_is_runtime_irrelevant(self) -> None:
+        config = self._load_from_data(
+            {
+                "_reasoning_effort_options": "documentation-only",
+                "flash_reasoning_effort": "low",
+                "pro_reasoning_effort": "high",
+            }
+        )
+        self.assertEqual(config.flash_reasoning_effort, "low")
+        self.assertEqual(config.pro_reasoning_effort, "high")
+
+    def test_reasoning_effort_rejects_unknown_values(self) -> None:
+        for field in ("flash_reasoning_effort", "pro_reasoning_effort"):
+            with self.subTest(field=field), self.assertRaisesRegex(
+                RuntimeError, "none, low, high, max"
+            ):
+                self._load_from_data({field: "ultra"})
 
     def test_legacy_single_model_maps_to_both_slots(self) -> None:
         config = self._load_from_data({"model": "vendor-legacy-model"})

--- a/tests/test_config_model_slots.py
+++ b/tests/test_config_model_slots.py
@@ -10,6 +10,7 @@ from deepseek_mcp.config import (
     DEFAULT_FLASH_MODEL,
     DEFAULT_PRO_MODEL,
     DEFAULT_REASONING_EFFORT,
+    PROVIDER_DEFAULT_REASONING_EFFORT,
     REASONING_EFFORT_OPTIONS,
 )
 
@@ -25,14 +26,19 @@ class ConfigModelSlotTests(unittest.TestCase):
             ):
                 return Config.load()
 
-    def test_flash_and_pro_have_official_defaults(self) -> None:
+    def test_flash_and_pro_have_official_model_defaults(self) -> None:
         config = self._load_from_data({})
         self.assertEqual(config.flash_model, DEFAULT_FLASH_MODEL)
         self.assertEqual(config.pro_model, DEFAULT_PRO_MODEL)
         self.assertEqual(config.model, DEFAULT_FLASH_MODEL)
-        self.assertEqual(config.flash_reasoning_effort, DEFAULT_REASONING_EFFORT)
-        self.assertEqual(config.pro_reasoning_effort, DEFAULT_REASONING_EFFORT)
-        self.assertEqual(config.reasoning_effort, DEFAULT_REASONING_EFFORT)
+        self.assertEqual(DEFAULT_REASONING_EFFORT, "high")
+        self.assertEqual(
+            config.flash_reasoning_effort, PROVIDER_DEFAULT_REASONING_EFFORT
+        )
+        self.assertEqual(
+            config.pro_reasoning_effort, PROVIDER_DEFAULT_REASONING_EFFORT
+        )
+        self.assertEqual(config.reasoning_effort, PROVIDER_DEFAULT_REASONING_EFFORT)
         self.assertEqual(REASONING_EFFORT_OPTIONS, ("none", "low", "high", "max"))
 
     def test_flash_and_pro_accept_user_provider_model_names_and_efforts(self) -> None:
@@ -52,6 +58,13 @@ class ConfigModelSlotTests(unittest.TestCase):
         self.assertEqual(config.pro_reasoning_effort, "max")
         self.assertEqual(config.reasoning_effort, "none")
 
+    def test_reasoning_effort_can_be_configured_per_slot_independently(self) -> None:
+        config = self._load_from_data({"flash_reasoning_effort": "low"})
+        self.assertEqual(config.flash_reasoning_effort, "low")
+        self.assertEqual(
+            config.pro_reasoning_effort, PROVIDER_DEFAULT_REASONING_EFFORT
+        )
+
     def test_reasoning_effort_hint_field_is_runtime_irrelevant(self) -> None:
         config = self._load_from_data(
             {
@@ -70,11 +83,19 @@ class ConfigModelSlotTests(unittest.TestCase):
             ):
                 self._load_from_data({field: "ultra"})
 
-    def test_legacy_single_model_maps_to_both_slots(self) -> None:
+    def test_internal_provider_default_marker_is_not_a_user_option(self) -> None:
+        for field in ("flash_reasoning_effort", "pro_reasoning_effort"):
+            with self.subTest(field=field), self.assertRaisesRegex(
+                RuntimeError, "none, low, high, max"
+            ):
+                self._load_from_data({field: PROVIDER_DEFAULT_REASONING_EFFORT})
+
+    def test_legacy_single_model_maps_to_both_slots_without_new_reasoning_fields(self) -> None:
         config = self._load_from_data({"model": "vendor-legacy-model"})
         self.assertEqual(config.flash_model, "vendor-legacy-model")
         self.assertEqual(config.pro_model, "vendor-legacy-model")
         self.assertEqual(config.model, "vendor-legacy-model")
+        self.assertEqual(config.reasoning_effort, PROVIDER_DEFAULT_REASONING_EFFORT)
 
     def test_legacy_model_cannot_be_mixed_with_new_slots(self) -> None:
         for data in (

--- a/tests/test_config_model_slots.py
+++ b/tests/test_config_model_slots.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from deepseek_mcp.config import (
+    Config,
+    DEFAULT_FLASH_MODEL,
+    DEFAULT_PRO_MODEL,
+)
+
+
+class ConfigModelSlotTests(unittest.TestCase):
+    def _load_from_data(self, data: dict) -> Config:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            with (
+                patch("deepseek_mcp.config._load_data", return_value=data),
+                patch("deepseek_mcp.config._load_api_key", return_value="sk-test"),
+                patch("deepseek_mcp.config._load_workspace", return_value=workspace),
+            ):
+                return Config.load()
+
+    def test_flash_and_pro_have_official_defaults(self) -> None:
+        config = self._load_from_data({})
+        self.assertEqual(config.flash_model, DEFAULT_FLASH_MODEL)
+        self.assertEqual(config.pro_model, DEFAULT_PRO_MODEL)
+        self.assertEqual(config.model, DEFAULT_FLASH_MODEL)
+
+    def test_flash_and_pro_accept_user_provider_model_names(self) -> None:
+        config = self._load_from_data(
+            {"flash": "deepseek-v4.1-flash", "pro": "deepseek-v4.1-pro"}
+        )
+        self.assertEqual(config.flash_model, "deepseek-v4.1-flash")
+        self.assertEqual(config.pro_model, "deepseek-v4.1-pro")
+        self.assertEqual(config.model, "deepseek-v4.1-flash")
+
+    def test_legacy_single_model_maps_to_both_slots(self) -> None:
+        config = self._load_from_data({"model": "vendor-legacy-model"})
+        self.assertEqual(config.flash_model, "vendor-legacy-model")
+        self.assertEqual(config.pro_model, "vendor-legacy-model")
+        self.assertEqual(config.model, "vendor-legacy-model")
+
+    def test_legacy_model_cannot_be_mixed_with_new_slots(self) -> None:
+        for data in (
+            {"model": "legacy", "flash": "fast"},
+            {"model": "legacy", "pro": "smart"},
+        ):
+            with self.subTest(data=data), self.assertRaisesRegex(
+                RuntimeError, "cannot be combined"
+            ):
+                self._load_from_data(data)
+
+    def test_model_slot_values_are_strict_strings(self) -> None:
+        for data in (
+            {"flash": ""},
+            {"pro": " pro-model "},
+            {"flash": 123},
+        ):
+            with self.subTest(data=data), self.assertRaisesRegex(
+                RuntimeError, "flash|pro"
+            ):
+                self._load_from_data(data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -11,7 +11,12 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 from deepseek_mcp import server
-from deepseek_mcp.config import Config, DEFAULT_MODEL
+from deepseek_mcp.config import (
+    Config,
+    DEFAULT_FLASH_MODEL,
+    DEFAULT_MODEL,
+    DEFAULT_PRO_MODEL,
+)
 from deepseek_mcp.execution_profile import CODING_PROFILE, READONLY_PROFILE
 from deepseek_mcp.model_selection import resolve_model
 
@@ -21,7 +26,9 @@ class ModelSelectionTests(unittest.TestCase):
         return Config("sk-test", workspace, allowed_tools=["Read"])
 
     def test_config_and_public_tools_default_to_flash(self) -> None:
-        self.assertEqual(DEFAULT_MODEL, "deepseek-v4-flash")
+        self.assertEqual(DEFAULT_MODEL, DEFAULT_FLASH_MODEL)
+        self.assertEqual(DEFAULT_FLASH_MODEL, "deepseek-v4-flash")
+        self.assertEqual(DEFAULT_PRO_MODEL, "deepseek-v4-pro")
         for tool in (
             server.delegate_to_deepseek,
             server.delegate_to_deepseek_readonly,
@@ -31,16 +38,35 @@ class ModelSelectionTests(unittest.TestCase):
             parameter = inspect.signature(tool).parameters["model"]
             self.assertEqual(parameter.default, "flash")
 
-    def test_model_aliases_are_exact(self) -> None:
-        self.assertEqual(resolve_model("flash"), "deepseek-v4-flash")
-        self.assertEqual(resolve_model("pro"), "deepseek-v4-pro")
+    def test_model_profiles_resolve_user_configured_provider_ids(self) -> None:
+        self.assertEqual(
+            resolve_model(
+                "flash",
+                flash_model="vendor-fast-model",
+                pro_model="vendor-smart-model",
+            ),
+            "vendor-fast-model",
+        )
+        self.assertEqual(
+            resolve_model(
+                "pro",
+                flash_model="vendor-fast-model",
+                pro_model="vendor-smart-model",
+            ),
+            "vendor-smart-model",
+        )
         with self.assertRaisesRegex(ValueError, "flash.*pro"):
-            resolve_model("other")
+            resolve_model(
+                "other",
+                flash_model="vendor-fast-model",
+                pro_model="vendor-smart-model",
+            )
 
-    def test_load_config_overrides_legacy_config_model_with_flash_by_default(self) -> None:
+    def test_load_config_uses_configured_flash_by_default(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             config = self._config(Path(tmpdir))
-            config.model = "legacy-configured-model"
+            config.flash_model = "custom-flash"
+            config.pro_model = "custom-pro"
             with (
                 patch.object(server.Config, "load", return_value=config),
                 patch.object(server, "configure_delegation", side_effect=lambda cfg, _profile: cfg),
@@ -48,23 +74,25 @@ class ModelSelectionTests(unittest.TestCase):
                 loaded = server._load_config(CODING_PROFILE)
 
         self.assertIs(loaded, config)
-        self.assertEqual(loaded.model, "deepseek-v4-flash")
+        self.assertEqual(loaded.model, "custom-flash")
 
-    def test_load_config_can_select_pro(self) -> None:
+    def test_load_config_can_select_configured_pro(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             config = self._config(Path(tmpdir))
+            config.flash_model = "custom-flash"
+            config.pro_model = "custom-pro"
             with (
                 patch.object(server.Config, "load", return_value=config),
                 patch.object(server, "configure_delegation", side_effect=lambda cfg, _profile: cfg),
             ):
                 loaded = server._load_config(READONLY_PROFILE, "pro")
 
-        self.assertEqual(loaded.model, "deepseek-v4-pro")
+        self.assertEqual(loaded.model, "custom-pro")
 
     def test_background_job_receives_selected_model_once(self) -> None:
         manager = Mock()
         manager.start.return_value = {"job_id": "job-1", "status": "running"}
-        config = Mock(model="deepseek-v4-pro")
+        config = Mock(model="custom-pro")
         with (
             patch.object(server, "job_manager", manager),
             patch.object(server, "_load_config", return_value=config) as load_config,

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -62,11 +62,13 @@ class ModelSelectionTests(unittest.TestCase):
                 pro_model="vendor-smart-model",
             )
 
-    def test_load_config_uses_configured_flash_by_default(self) -> None:
+    def test_load_config_uses_configured_flash_profile_by_default(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             config = self._config(Path(tmpdir))
             config.flash_model = "custom-flash"
             config.pro_model = "custom-pro"
+            config.flash_reasoning_effort = "low"
+            config.pro_reasoning_effort = "max"
             with (
                 patch.object(server.Config, "load", return_value=config),
                 patch.object(server, "configure_delegation", side_effect=lambda cfg, _profile: cfg),
@@ -75,12 +77,15 @@ class ModelSelectionTests(unittest.TestCase):
 
         self.assertIs(loaded, config)
         self.assertEqual(loaded.model, "custom-flash")
+        self.assertEqual(loaded.reasoning_effort, "low")
 
-    def test_load_config_can_select_configured_pro(self) -> None:
+    def test_load_config_can_select_configured_pro_profile(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             config = self._config(Path(tmpdir))
             config.flash_model = "custom-flash"
             config.pro_model = "custom-pro"
+            config.flash_reasoning_effort = "none"
+            config.pro_reasoning_effort = "max"
             with (
                 patch.object(server.Config, "load", return_value=config),
                 patch.object(server, "configure_delegation", side_effect=lambda cfg, _profile: cfg),
@@ -88,11 +93,12 @@ class ModelSelectionTests(unittest.TestCase):
                 loaded = server._load_config(READONLY_PROFILE, "pro")
 
         self.assertEqual(loaded.model, "custom-pro")
+        self.assertEqual(loaded.reasoning_effort, "max")
 
     def test_background_job_receives_selected_model_once(self) -> None:
         manager = Mock()
         manager.start.return_value = {"job_id": "job-1", "status": "running"}
-        config = Mock(model="custom-pro")
+        config = Mock(model="custom-pro", reasoning_effort="max")
         with (
             patch.object(server, "job_manager", manager),
             patch.object(server, "_load_config", return_value=config) as load_config,

--- a/tests/test_reasoning_effort.py
+++ b/tests/test_reasoning_effort.py
@@ -1,17 +1,34 @@
 from __future__ import annotations
 
+import json
 import unittest
+from types import SimpleNamespace
 
+from deepseek_mcp.config import PROVIDER_DEFAULT_REASONING_EFFORT
 from deepseek_mcp.provider_child import _request_arguments
+from deepseek_mcp.provider_process import _encoded_request
 
 
 class ReasoningEffortRequestTests(unittest.TestCase):
+    messages = [{"role": "user", "content": "test"}]
+
     def _arguments(self, effort: str) -> dict:
         return _request_arguments(
             {"model": "configured-model", "reasoning_effort": effort},
-            [{"role": "user", "content": "test"}],
+            self.messages,
             [],
         )
+
+    def _encoded_settings(self, *, effort: str | None = None, include: bool = True) -> dict:
+        config = SimpleNamespace(
+            api_key="sk-test",
+            base_url="https://api.deepseek.com",
+            model="configured-model",
+        )
+        if include:
+            config.reasoning_effort = effort
+        payload = json.loads(_encoded_request(config, self.messages, []))
+        return payload["settings"]
 
     def test_none_disables_thinking_without_invalid_reasoning_effort(self) -> None:
         arguments = self._arguments("none")
@@ -27,14 +44,36 @@ class ReasoningEffortRequestTests(unittest.TestCase):
                     arguments["extra_body"], {"thinking": {"type": "enabled"}}
                 )
 
-    def test_missing_effort_keeps_previous_high_default(self) -> None:
-        arguments = _request_arguments(
-            {"model": "configured-model"},
-            [{"role": "user", "content": "test"}],
-            [],
-        )
-        self.assertEqual(arguments["reasoning_effort"], "high")
-        self.assertEqual(arguments["extra_body"], {"thinking": {"type": "enabled"}})
+    def test_missing_effort_keeps_legacy_request_shape(self) -> None:
+        settings = self._encoded_settings(include=False)
+        self.assertNotIn("reasoning_effort", settings)
+        arguments = _request_arguments(settings, self.messages, [])
+        self.assertNotIn("reasoning_effort", arguments)
+        self.assertNotIn("extra_body", arguments)
+
+    def test_provider_default_marker_keeps_legacy_request_shape(self) -> None:
+        settings = self._encoded_settings(effort=PROVIDER_DEFAULT_REASONING_EFFORT)
+        self.assertNotIn("reasoning_effort", settings)
+        arguments = _request_arguments(settings, self.messages, [])
+        self.assertNotIn("reasoning_effort", arguments)
+        self.assertNotIn("extra_body", arguments)
+
+    def test_explicit_effort_survives_parent_child_request_boundary(self) -> None:
+        for effort in ("none", "low", "high", "max"):
+            with self.subTest(effort=effort):
+                settings = self._encoded_settings(effort=effort)
+                self.assertEqual(settings["reasoning_effort"], effort)
+                arguments = _request_arguments(settings, self.messages, [])
+                if effort == "none":
+                    self.assertNotIn("reasoning_effort", arguments)
+                    self.assertEqual(
+                        arguments["extra_body"], {"thinking": {"type": "disabled"}}
+                    )
+                else:
+                    self.assertEqual(arguments["reasoning_effort"], effort)
+                    self.assertEqual(
+                        arguments["extra_body"], {"thinking": {"type": "enabled"}}
+                    )
 
     def test_unknown_effort_is_rejected_before_network_call(self) -> None:
         with self.assertRaisesRegex(ValueError, "reasoning effort"):

--- a/tests/test_reasoning_effort.py
+++ b/tests/test_reasoning_effort.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import unittest
+
+from deepseek_mcp.provider_child import _request_arguments
+
+
+class ReasoningEffortRequestTests(unittest.TestCase):
+    def _arguments(self, effort: str) -> dict:
+        return _request_arguments(
+            {"model": "configured-model", "reasoning_effort": effort},
+            [{"role": "user", "content": "test"}],
+            [],
+        )
+
+    def test_none_disables_thinking_without_invalid_reasoning_effort(self) -> None:
+        arguments = self._arguments("none")
+        self.assertEqual(arguments["extra_body"], {"thinking": {"type": "disabled"}})
+        self.assertNotIn("reasoning_effort", arguments)
+
+    def test_low_high_and_max_enable_thinking_with_exact_effort(self) -> None:
+        for effort in ("low", "high", "max"):
+            with self.subTest(effort=effort):
+                arguments = self._arguments(effort)
+                self.assertEqual(arguments["reasoning_effort"], effort)
+                self.assertEqual(
+                    arguments["extra_body"], {"thinking": {"type": "enabled"}}
+                )
+
+    def test_missing_effort_keeps_previous_high_default(self) -> None:
+        arguments = _request_arguments(
+            {"model": "configured-model"},
+            [{"role": "user", "content": "test"}],
+            [],
+        )
+        self.assertEqual(arguments["reasoning_effort"], "high")
+        self.assertEqual(arguments["extra_body"], {"thinking": {"type": "enabled"}})
+
+    def test_unknown_effort_is_rejected_before_network_call(self) -> None:
+        with self.assertRaisesRegex(ValueError, "reasoning effort"):
+            self._arguments("ultra")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep the public MCP routing argument limited to `model="flash" | "pro"`
- make the actual provider model IDs user-configurable through `config.json` fields `flash` and `pro`
- make reasoning effort independently configurable per slot through `flash_reasoning_effort` and `pro_reasoning_effort`
- support exactly `none`, `low`, `high`, and `max`; `none` disables thinking and the other values enable thinking at that effort
- add `_reasoning_effort_options` as a documentation-only config hint listing all supported values; runtime ignores this field
- have new installer-generated configs explicitly set both effort slots to `high`
- preserve legacy/provider compatibility by leaving thinking controls unspecified when a slot has no explicit reasoning-effort field
- keep old single `model` configs working by mapping that value to both model slots when `flash`/`pro` are absent
- reject mixing legacy `model` with the new model slot fields to avoid ambiguous configuration
- update Claude/Codex installer templates, README examples, model-selection documentation, skill, and `/ds` guidance
- keep background jobs pinned to the model profile and resolved reasoning behavior selected at start
- add contract tests for custom model IDs, per-slot effort selection, `none` behavior, legacy request shape, and the parent→provider-child request boundary

## Intended config
```json
{
  "flash": "deepseek-v4-flash",
  "flash_reasoning_effort": "high",
  "pro": "deepseek-v4-pro",
  "pro_reasoning_effort": "high",
  "_reasoning_effort_options": ["none", "low", "high", "max"]
}
```

Users can replace the model strings when DeepSeek model names change without changing the MCP tool API. The two `*_reasoning_effort` fields are effective runtime settings; `_reasoning_effort_options` is only an in-file hint.

## Compatibility
Existing tool calls that omit `model` still default to the Flash profile. Existing config files containing only the legacy `model` field remain loadable and preserve their single-model behavior for both routing profiles. If a reasoning-effort field is absent, deepseek-mcp does not add `thinking` or `reasoning_effort` to that slot's provider request, preserving the older request shape and letting the provider's existing default apply. New installer-generated configs explicitly set both slots to `high`.